### PR TITLE
Deps update: Compose beta

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.0-beta04'
+        classpath 'com.android.tools.build:gradle:4.2.0-beta05'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${Libs.Kotlin.version}"
         classpath "com.google.dagger:hilt-android-gradle-plugin:${Libs.Hilt.androidVersion}"
 

--- a/buildSrc/src/main/java/com/enricog/tempo/buildsrc/dependencies.kt
+++ b/buildSrc/src/main/java/com/enricog/tempo/buildsrc/dependencies.kt
@@ -49,7 +49,7 @@ object Libs {
         }
 
         object Compose {
-            const val version = "1.0.0-alpha12"
+            const val version = "1.0.0-beta01"
 
             const val runtime = "androidx.compose.runtime:runtime:$version"
             const val foundation = "androidx.compose.foundation:foundation:$version"
@@ -63,11 +63,11 @@ object Libs {
             const val test = "androidx.compose.ui:ui-test:$version"
             const val uiTest = "androidx.compose.ui:ui-test-junit4:$version"
 
-            const val activity = "androidx.activity:activity-compose:1.3.0-alpha02"
+            const val activity = "androidx.activity:activity-compose:1.3.0-alpha03"
 
-            const val navigation = "androidx.navigation:navigation-compose:1.0.0-alpha07"
-            const val viewModel = "androidx.lifecycle:lifecycle-viewmodel-compose:1.0.0-alpha01"
-            const val constraintLayout = "androidx.constraintlayout:constraintlayout-compose:1.0.0-alpha02"
+            const val navigation = "androidx.navigation:navigation-compose:1.0.0-alpha08"
+            const val viewModel = "androidx.lifecycle:lifecycle-viewmodel-compose:1.0.0-alpha02"
+            const val constraintLayout = "androidx.constraintlayout:constraintlayout-compose:1.0.0-alpha03"
         }
     }
 
@@ -83,7 +83,7 @@ object Libs {
     }
 
     object Hilt {
-        const val androidVersion = "2.32-alpha"
+        const val androidVersion = "2.33-beta"
         private const val version = "1.0.0-alpha03"
 
         const val android = "com.google.dagger:hilt-android:$androidVersion"
@@ -98,7 +98,7 @@ object Libs {
     }
 
     object Room {
-        private const val version = "2.2.5"
+        private const val version = "2.2.6"
 
         const val runtime = "androidx.room:room-runtime:$version"
         const val compiler = "androidx.room:room-compiler:$version"

--- a/features/routines/src/main/java/com/enricog/routines/detail/routine/ui_components/RoutineFormScene.kt
+++ b/features/routines/src/main/java/com/enricog/routines/detail/routine/ui_components/RoutineFormScene.kt
@@ -39,7 +39,7 @@ internal fun RoutineFormScene(
             modifier = Modifier
                 .fillMaxWidth()
                 .weight(1f)
-                .verticalScroll(rememberScrollState(initial = 0f))
+                .verticalScroll(rememberScrollState(initial = 0))
         ) {
             RoutineNameTextField(
                 value = routine.name,

--- a/features/routines/src/main/java/com/enricog/routines/detail/segment/ui_components/SegmentFormScene.kt
+++ b/features/routines/src/main/java/com/enricog/routines/detail/segment/ui_components/SegmentFormScene.kt
@@ -50,7 +50,7 @@ internal fun SegmentFormScene(
             modifier = Modifier
                 .fillMaxWidth()
                 .weight(1f)
-                .verticalScroll(rememberScrollState(0f))
+                .verticalScroll(rememberScrollState(0))
         ) {
             SegmentNameTextField(
                 value = segment.name,

--- a/features/routines/src/main/java/com/enricog/routines/detail/summary/ui_components/RoutineSummaryScene.kt
+++ b/features/routines/src/main/java/com/enricog/routines/detail/summary/ui_components/RoutineSummaryScene.kt
@@ -7,7 +7,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.preferredHeight
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material.MaterialTheme
@@ -51,7 +51,16 @@ internal fun RoutineSummaryScene(
             verticalArrangement = Arrangement.spacedBy(MaterialTheme.dimensions.spaceM),
             contentPadding = PaddingValues(MaterialTheme.dimensions.spaceM)
         ) {
-            itemsIndexed(summaryItems) { index, item ->
+            itemsIndexed(
+                items = summaryItems,
+                key = { _, item ->
+                    when (item) {
+                        is RoutineSummaryItem.RoutineInfo -> item.hashCode()
+                        is RoutineSummaryItem.SegmentSectionTitle -> item.hashCode()
+                        is RoutineSummaryItem.SegmentItem -> item.segment.id
+                    }.exhaustive
+                }
+            ) { index, item ->
                 when (item) {
                     is RoutineSummaryItem.RoutineInfo -> {
                         RoutineSection(
@@ -72,7 +81,7 @@ internal fun RoutineSummaryScene(
                     }
                 }.exhaustive
                 if (index == summaryItems.size - 1) {
-                    Spacer(Modifier.preferredHeight(segmentListBottomSpace))
+                    Spacer(Modifier.width(segmentListBottomSpace))
                 }
             }
         }

--- a/features/routines/src/main/java/com/enricog/routines/list/ui_components/RoutinesScene.kt
+++ b/features/routines/src/main/java/com/enricog/routines/list/ui_components/RoutinesScene.kt
@@ -42,7 +42,10 @@ internal fun RoutinesScene(
             verticalArrangement = Arrangement.spacedBy(MaterialTheme.dimensions.spaceM),
             contentPadding = PaddingValues(MaterialTheme.dimensions.spaceM)
         ) {
-            items(routines) { routine ->
+            items(
+                items = routines,
+                key = { routine -> routine.id }
+            ) { routine ->
                 RoutineItem(
                     modifier = Modifier.fillMaxWidth(),
                     routine = routine,

--- a/features/routines/src/main/java/com/enricog/routines/ui_components/DeleteableListItem.kt
+++ b/features/routines/src/main/java/com/enricog/routines/ui_components/DeleteableListItem.kt
@@ -2,6 +2,7 @@ package com.enricog.routines.ui_components
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -18,7 +19,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.gesture.scrollorientationlocking.Orientation
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.IntOffset
@@ -29,8 +29,6 @@ import com.enricog.routines.ui_components.SwipeableState.OPEN
 import com.enricog.ui_components.resources.commonShapes
 import com.enricog.ui_components.resources.dimensions
 import kotlin.math.roundToInt
-
-// FIXME the swipe state is remembered for deleted items; deleted item's state is applied to the one below
 
 private enum class SwipeableState {
     CLOSE,
@@ -68,10 +66,7 @@ internal fun DeletableListItem(
                     .fillMaxWidth(0.5f)
                     .clip(MaterialTheme.commonShapes.listItem)
                     .background(MaterialTheme.colors.error)
-                    .clickable {
-                        onDelete()
-                        swipeState.snapTo(CLOSE)
-                    },
+                    .clickable { onDelete() },
                 contentAlignment = Alignment.CenterEnd
             ) {
                 Text(
@@ -86,7 +81,7 @@ internal fun DeletableListItem(
         Surface(
             modifier = Modifier
                 .fillMaxWidth()
-                .offset { IntOffset(swipeState.offset.value.roundToInt(), 0) },
+                .offset { IntOffset(x = swipeState.offset.value.roundToInt(), y = 0) },
             shape = MaterialTheme.commonShapes.listItem,
             content = content
         )

--- a/features/timer/src/main/java/com/enricog/timer/ui_components/Clock.kt
+++ b/features/timer/src/main/java/com/enricog/timer/ui_components/Clock.kt
@@ -18,7 +18,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.SpanStyleRange
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.BaselineShift
 import androidx.compose.ui.text.style.TextAlign
@@ -87,7 +86,7 @@ private fun buildTimeText(timeInSeconds: Long): AnnotatedString {
 
     val timeBuilder = StringBuilder()
     var format = "%01d"
-    val spanStyles = mutableListOf<SpanStyleRange>()
+    val spanStyles = mutableListOf<AnnotatedString.Range<SpanStyle>>()
     var from = 0
     var to = 0
 
@@ -95,19 +94,19 @@ private fun buildTimeText(timeInSeconds: Long): AnnotatedString {
         format = "%02d"
         val minutesString = String.format(format, minutes)
         to = minutesString.length
-        spanStyles.add(SpanStyleRange(NumberStyle, 0, to))
+        spanStyles.add(AnnotatedString.Range(NumberStyle, 0, to))
         timeBuilder.append(minutesString)
 
         from = to
         to += 1
-        spanStyles.add(SpanStyleRange(SeparatorStyle, from, to))
+        spanStyles.add(AnnotatedString.Range(SeparatorStyle, from, to))
         timeBuilder.append(":")
         from += 1
     }
     val secondsString = String.format(format, seconds)
     to += secondsString.length
     timeBuilder.append(secondsString)
-    spanStyles.add(SpanStyleRange(NumberStyle, from, to))
+    spanStyles.add(AnnotatedString.Range(NumberStyle, from, to))
 
     return AnnotatedString(text = timeBuilder.toString(), spanStyles = spanStyles)
 }

--- a/ui_components/src/main/java/com/enricog/ui_components/common/button/TempoButton.kt
+++ b/ui_components/src/main/java/com/enricog/ui_components/common/button/TempoButton.kt
@@ -7,7 +7,7 @@ import androidx.compose.material.LocalElevationOverlay
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.Providers
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
@@ -25,7 +25,7 @@ fun TempoButton(
     require(contentDescription.isNotBlank()) { "contentDescription cannot be blank" }
     require(text.isNotBlank()) { "text cannot be blank" }
 
-    Providers(
+    CompositionLocalProvider(
         LocalElevationOverlay provides null
     ) {
         Button(

--- a/ui_components/src/main/java/com/enricog/ui_components/common/dialog/TempoDialog.kt
+++ b/ui_components/src/main/java/com/enricog/ui_components/common/dialog/TempoDialog.kt
@@ -6,9 +6,9 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.preferredHeight
-import androidx.compose.foundation.layout.preferredWidth
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
@@ -47,7 +47,7 @@ fun TempoDialogAlert(
                     style = MaterialTheme.typography.h1,
                     color = MaterialTheme.colors.onSurface
                 )
-                Spacer(modifier = Modifier.preferredHeight(10.dp))
+                Spacer(modifier = Modifier.height(10.dp))
                 Text(
                     text = description,
                     style = MaterialTheme.typography.body1,
@@ -66,7 +66,7 @@ fun TempoDialogAlert(
                         text = negativeAction.text,
                         contentDescription = negativeAction.contentDescription
                     )
-                    Spacer(modifier = Modifier.preferredWidth(16.dp))
+                    Spacer(modifier = Modifier.width(16.dp))
                 }
                 TempoButton(
                     onClick = positiveAction.onClick,

--- a/ui_components/src/main/java/com/enricog/ui_components/common/textField/TempoTextField.kt
+++ b/ui_components/src/main/java/com/enricog/ui_components/common/textField/TempoTextField.kt
@@ -117,12 +117,12 @@ private fun TempoTextFieldBase(
             label = labelText,
             leadingIcon = leadingIcon,
             trailingIcon = trailingIcon,
-            isErrorValue = errorMessage != null,
+            isError = errorMessage != null,
             visualTransformation = visualTransformation,
             keyboardOptions = keyboardOptions,
             singleLine = singleLine,
             maxLines = maxLines,
-            backgroundColor = MaterialTheme.colors.surface
+            // backgroundColor = MaterialTheme.colors.surface
         )
         if (errorMessage != null) {
             Text(

--- a/ui_components/src/main/java/com/enricog/ui_components/common/toolbar/Toolbar.kt
+++ b/ui_components/src/main/java/com/enricog/ui_components/common/toolbar/Toolbar.kt
@@ -10,7 +10,7 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.material.TopAppBar
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.Providers
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
@@ -25,7 +25,7 @@ fun TempoToolbar(
     onBack: (() -> Unit)? = null,
     title: String? = null
 ) {
-    Providers(
+    CompositionLocalProvider(
         LocalElevationOverlay provides null
     ) {
         TopAppBar(


### PR DESCRIPTION
Dependencies updated:
 - gradle 4.2.0-beta05
 - compose 1.0.0-beta01
 - activity-compose 1.3.0-alpha03
 - navigation-compose 1.0.0-alpha08
 - lifecycle-viewmodel-compose 1.0.0-alpha02
 - constraintlayout-compose 1.0.0-alpha03
 - hilt 2.33-beta
 - room 2.2.6

Fixed issue when deleting an item that was causing the next item to "take" the state of the deleted item:
since an item changing position lose any remembered state, we can solve this by setting a key for each item
refs: https://developer.android.com/jetpack/compose/lists#item-keys 
