### PR TITLE
Deps update: Compose beta02

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,12 +9,12 @@ buildscript {
         maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.0-beta05'
+        classpath 'com.android.tools.build:gradle:4.2.0-beta06'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${Libs.Kotlin.version}"
         classpath "com.google.dagger:hilt-android-gradle-plugin:${Libs.Hilt.androidVersion}"
 
         classpath 'com.google.gms:google-services:4.3.5'
-        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.5.0'
+        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.5.1'
 
         classpath "org.jlleitschuh.gradle:ktlint-gradle:9.4.1"
 
@@ -36,6 +36,7 @@ allprojects {
         mavenCentral()
         // TODO: remove when this are migrated to mavenCentral
         jcenter() {
+            //noinspection JcenterRepositoryObsolete
             content {
                 includeModule("org.jetbrains.kotlinx", "kotlinx-collections-immutable-jvm")
                 includeModule("com.linkedin.dexmaker", "dexmaker")
@@ -54,11 +55,6 @@ subprojects {
             if (group == 'org.jetbrains.kotlin' && module == 'kotlin-stdlib-jdk7') {
                 // Force kotlin-stdlib module version
                 details.useTarget Libs.Kotlin.stdlib
-            }
-
-            if (group == 'androidx.activity' && module == 'activity-compose') {
-                // FIXME Force activity-compose version; next compose release should fix this
-                details.useTarget Libs.AndroidX.Compose.activity
             }
         }
     }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,5 +1,5 @@
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 plugins {

--- a/buildSrc/src/main/java/com/enricog/tempo/buildsrc/dependencies.kt
+++ b/buildSrc/src/main/java/com/enricog/tempo/buildsrc/dependencies.kt
@@ -22,7 +22,7 @@ object Versions {
 object Libs {
 
     object Kotlin {
-        const val version = "1.4.30"
+        const val version = "1.4.31"
         private const val coroutineVersion = "1.4.2"
 
         const val coroutines = "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutineVersion"
@@ -49,7 +49,7 @@ object Libs {
         }
 
         object Compose {
-            const val version = "1.0.0-beta01"
+            const val version = "1.0.0-beta02"
 
             const val runtime = "androidx.compose.runtime:runtime:$version"
             const val foundation = "androidx.compose.foundation:foundation:$version"
@@ -63,11 +63,11 @@ object Libs {
             const val test = "androidx.compose.ui:ui-test:$version"
             const val uiTest = "androidx.compose.ui:ui-test-junit4:$version"
 
-            const val activity = "androidx.activity:activity-compose:1.3.0-alpha03"
+            const val activity = "androidx.activity:activity-compose:1.3.0-alpha04"
 
-            const val navigation = "androidx.navigation:navigation-compose:1.0.0-alpha08"
-            const val viewModel = "androidx.lifecycle:lifecycle-viewmodel-compose:1.0.0-alpha02"
-            const val constraintLayout = "androidx.constraintlayout:constraintlayout-compose:1.0.0-alpha03"
+            const val navigation = "androidx.navigation:navigation-compose:1.0.0-alpha09"
+            const val viewModel = "androidx.lifecycle:lifecycle-viewmodel-compose:1.0.0-alpha03"
+            const val constraintLayout = "androidx.constraintlayout:constraintlayout-compose:1.0.0-alpha05"
         }
     }
 
@@ -84,15 +84,14 @@ object Libs {
 
     object Hilt {
         const val androidVersion = "2.33-beta"
-        private const val version = "1.0.0-alpha03"
+        private const val version = "1.0.0-beta01"
 
         const val android = "com.google.dagger:hilt-android:$androidVersion"
         const val androidCompiler = "com.google.dagger:hilt-android-compiler:$androidVersion"
 
-        // TODO replace with hilt-navigation-compose when out
-        const val navigation = "androidx.hilt:hilt-navigation:$version"
+        const val navigation = "androidx.hilt:hilt-navigation-compose:1.0.0-alpha01"
 
-        const val lifecycleViewModel = "androidx.hilt:hilt-lifecycle-viewmodel:$version"
+        const val lifecycleViewModel = "androidx.hilt:hilt-lifecycle-viewmodel:1.0.0-alpha03"
         const val compiler = "androidx.hilt:hilt-compiler:$version"
         const val work = "androidx.hilt:hilt-work:$version"
     }
@@ -115,11 +114,11 @@ object Libs {
     }
 
     object Tools {
-        const val desugar = "com.android.tools:desugar_jdk_libs:1.0.9"
+        const val desugar = "com.android.tools:desugar_jdk_libs:1.1.5"
     }
 
     object Firebase {
-        private const val version = "26.5.0"
+        private const val version = "26.7.0"
 
         const val bom = "com.google.firebase:firebase-bom:$version"
         const val crashlytics = "com.google.firebase:firebase-crashlytics-ktx"
@@ -136,7 +135,7 @@ object Libs {
     const val Robolectric = "org.robolectric:robolectric:4.3.1"
 
     object Mockk {
-        private const val version = "1.10.6"
+        private const val version = "1.11.0"
 
         const val lib = "io.mockk:mockk:$version"
         const val android = "io.mockk:mockk-android:$version"


### PR DESCRIPTION
dependencies updated:
- build:gradle: 4.2.0-beta06
- firebase-crashlytics-gradle: 2.5.1
- kotlin: 1.4.31
- activity-compose: 1.3.0-alpha04
- navigation-compose: 1.0.0-alpha09
- lifecycle-viewmodel-compose: 1.0.0-alpha03
- constraintlayout-compose: 1.0.0-alpha05
- desugar_jdk_libs: 1.1.5
- firebase-bom: 26.7.0
- mockk: 1.11.0