### PR TITLE
Fix dialog buttons

### DIFF
--- a/ui_components/src/main/java/com/enricog/ui_components/common/button/TempoButton.kt
+++ b/ui_components/src/main/java/com/enricog/ui_components/common/button/TempoButton.kt
@@ -4,11 +4,10 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.Button
+import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.Icon
-import androidx.compose.material.LocalElevationOverlay
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.unit.dp
@@ -27,29 +26,30 @@ fun TempoButton(
     require(contentDescription.isNotBlank()) { "contentDescription cannot be blank" }
     require(text.isNotBlank()) { "text cannot be blank, use TempoIconButton if you need to show only an icon" }
 
-    CompositionLocalProvider(
-        LocalElevationOverlay provides null
+    Button(
+        onClick = onClick,
+        modifier = modifier,
+        enabled = enabled,
+        colors = color,
+        elevation = ButtonDefaults.elevation(
+            defaultElevation = 0.dp,
+            pressedElevation = 0.dp,
+            disabledElevation = 0.dp
+        )
     ) {
-        Button(
-            onClick = onClick,
-            modifier = modifier,
-            enabled = enabled,
-            colors = color
-        ) {
-            if (icon != null) {
-                Icon(
-                    painter = icon,
-                    tint = color.contentColor(enabled).value,
-                    contentDescription = contentDescription,
-                    modifier = Modifier.size(14.dp)
-                )
-                Spacer(modifier = Modifier.width(14.dp))
-            }
-            Text(
-                text = text,
-                style = TempoTheme.typography.button,
-                color = color.contentColor(enabled).value
+        if (icon != null) {
+            Icon(
+                painter = icon,
+                tint = color.contentColor(enabled).value,
+                contentDescription = contentDescription,
+                modifier = Modifier.size(14.dp)
             )
+            Spacer(modifier = Modifier.width(14.dp))
         }
+        Text(
+            text = text,
+            style = TempoTheme.typography.button,
+            color = color.contentColor(enabled).value
+        )
     }
 }

--- a/ui_components/src/main/java/com/enricog/ui_components/common/dialog/TempoDialog.kt
+++ b/ui_components/src/main/java/com/enricog/ui_components/common/dialog/TempoDialog.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
@@ -88,8 +89,30 @@ private fun TempoDialogBase(
         onDismissRequest = onDismiss,
         properties = DialogProperties(
             dismissOnBackPress = isCancellable,
-            dismissOnClickOutside = isCancellable
+            dismissOnClickOutside = isCancellable,
+            usePlatformDefaultWidth = false
         ),
         content = content
+    )
+}
+
+@Preview
+@Composable
+private fun Preview() {
+    TempoDialogAlert(
+        title = "title",
+        description = "description",
+        positiveAction = TempoDialogAction(
+            text = "positive",
+            contentDescription = "positive",
+            onClick = {}
+        ),
+        negativeAction = TempoDialogAction(
+            text = "negative",
+            contentDescription = "negative",
+            onClick = {}
+        ),
+        onDismiss = { },
+        isCancellable = false
     )
 }


### PR DESCRIPTION
Fix dialog buttons not showing caused by the dialog property `usePlatformDefaultWidth` is set to default to `true`