### PR TITLE
Some random fixes

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -27,7 +27,7 @@ jobs:
             ~/.gradle/wrapper
           key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle*') }}-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}-${{ hashFiles('**/buildSrc/**/*.kt') }}
 
-      - name: set up JDK 1.8
+      - name: set up JDK 11
         uses: actions/setup-java@v1
         with:
           java-version: '11'
@@ -43,8 +43,8 @@ jobs:
         env:
           ENCRYPT_KEY: ${{ secrets.TEMPO_ENCRYPT_KEY }}
 
-      - name: Build project
-        run: ./gradlew build --stacktrace
+#      - name: Build project
+#        run: ./gradlew assembleDebug --stacktrace
 
       - name: Run unit-tests
         run: ./gradlew test testDebugUnitTest

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,6 +1,8 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
     <JetCodeStyleSettings>
+      <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />
+      <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>
     <codeStyleSettings language="XML">

--- a/entities/build.gradle
+++ b/entities/build.gradle
@@ -12,4 +12,10 @@ java {
 
 dependencies {
     implementation Libs.Kotlin.stdlib
+
+    testImplementation Libs.Test.junit
+}
+
+task testDebugUnitTest() {
+    dependsOn test
 }

--- a/entities/src/test/java/com/enricog/entities/SecondsTest.kt
+++ b/entities/src/test/java/com/enricog/entities/SecondsTest.kt
@@ -3,6 +3,7 @@ package com.enricog.entities
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
+
 class SecondsTest {
 
     @Test

--- a/features/routines/src/main/java/com/enricog/routines/detail/summary/ui_components/SegmentItem.kt
+++ b/features/routines/src/main/java/com/enricog/routines/detail/summary/ui_components/SegmentItem.kt
@@ -7,11 +7,15 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.constraintlayout.compose.Dimension
 import com.enricog.entities.routines.Segment
+import com.enricog.entities.routines.TimeType
+import com.enricog.entities.seconds
 import com.enricog.routines.detail.ui_components.TimeTypeChip
 import com.enricog.routines.ui_components.DeletableListItem
+import com.enricog.ui_components.extensions.format
 import com.enricog.ui_components.resources.TempoTheme
 
 internal const val SegmentItemTestTag = "SegmentItemTestTag"
@@ -29,7 +33,8 @@ internal fun SegmentItem(
         onDelete = { onDelete(segment) }
     ) {
         ConstraintLayout(
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier
+                .fillMaxWidth()
                 .clickable { onClick(segment) }
                 .padding(TempoTheme.dimensions.spaceM)
         ) {
@@ -68,9 +73,25 @@ internal fun SegmentItem(
                         end.linkTo(parent.end)
                         bottom.linkTo(parent.bottom)
                     },
-                text = "${segment.time.value}s",
+                text = segment.time.format(),
                 style = TempoTheme.typography.h3
             )
         }
     }
+}
+
+@Preview
+@Composable
+private fun SegmentItemPreview() {
+    SegmentItem(
+        modifier = Modifier,
+        segment = Segment(
+            id = 0L,
+            name = "Segment name",
+            time = 100.seconds,
+            type = TimeType.REST
+        ),
+        onClick = {},
+        onDelete = {}
+    )
 }

--- a/ui_components/src/main/java/com/enricog/ui_components/common/textField/TempoTextField.kt
+++ b/ui_components/src/main/java/com/enricog/ui_components/common/textField/TempoTextField.kt
@@ -3,9 +3,11 @@ package com.enricog.ui_components.common.textField
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.input.VisualTransformation
@@ -27,15 +29,14 @@ fun TempoTextField(
     singleLine: Boolean = false,
     maxLines: Int = Int.MAX_VALUE,
 ) {
-    val textFieldValue = remember(value) {
-        TextFieldValue(
-            text = value,
-            selection = TextRange(value.length),
-            composition = TextRange(0, value.length)
-        )
-    }
+    var textFieldValueState by remember { mutableStateOf(TextFieldValue(text = value)) }
+    val textFieldValue = textFieldValueState.copy(text = value)
+
     val textFieldValueChangeCallback = { textValue: TextFieldValue ->
-        onValueChange(textValue.text)
+        textFieldValueState = textValue
+        if (textValue.text != value) {
+            onValueChange(textValue.text)
+        }
     }
     TempoTextFieldBase(
         value = textFieldValue,

--- a/ui_components/src/main/java/com/enricog/ui_components/common/textField/TempoTextFieldBase.kt
+++ b/ui_components/src/main/java/com/enricog/ui_components/common/textField/TempoTextFieldBase.kt
@@ -42,7 +42,10 @@ internal fun TempoTextFieldBase(
     keyboardActions: KeyboardActions,
     singleLine: Boolean,
     maxLines: Int,
-    shape: Shape = TempoTheme.shapes.small.copy(bottomEnd = ZeroCornerSize, bottomStart = ZeroCornerSize),
+    shape: Shape = TempoTheme.shapes.small.copy(
+        bottomEnd = ZeroCornerSize,
+        bottomStart = ZeroCornerSize
+    ),
 ) {
     val composableLabel: @Composable (() -> Unit)? = label?.let { @Composable { Text(label) } }
     Column(
@@ -65,13 +68,18 @@ internal fun TempoTextFieldBase(
             shape = shape
         )
         if (errorMessage != null) {
-            Text(
-                modifier = Modifier.padding(top = TempoTheme.dimensions.spaceS),
-                text = errorMessage,
-                style = TempoTheme.typography.caption,
-                maxLines = 1,
-                color = TempoTheme.colors.error
-            )
+            TempoTextFieldBaseErrorText(errorMessage)
         }
     }
+}
+
+@Composable
+internal fun TempoTextFieldBaseErrorText(message: String) {
+    Text(
+        modifier = Modifier.padding(top = TempoTheme.dimensions.spaceS),
+        text = message,
+        style = TempoTheme.typography.caption,
+        maxLines = 1,
+        color = TempoTheme.colors.error
+    )
 }

--- a/ui_components/src/main/java/com/enricog/ui_components/common/textField/TempoTimeField.kt
+++ b/ui_components/src/main/java/com/enricog/ui_components/common/textField/TempoTimeField.kt
@@ -103,7 +103,7 @@ fun TempoTimeField(
                 label = stringResource(id = R.string.label_minutes),
                 leadingIcon = null,
                 trailingIcon = null,
-                errorMessage = errorMessage,
+                errorMessage = null,
                 keyboardOptions = KeyboardOptions(
                     keyboardType = KeyboardType.Number,
                     imeAction = ImeAction.Next
@@ -128,7 +128,7 @@ fun TempoTimeField(
                 label = stringResource(id = R.string.label_seconds),
                 leadingIcon = null,
                 trailingIcon = null,
-                errorMessage = errorMessage,
+                errorMessage = null,
                 keyboardOptions = KeyboardOptions(
                     keyboardType = KeyboardType.Number,
                     imeAction = imeAction
@@ -143,6 +143,9 @@ fun TempoTimeField(
                     topStart = ZeroCornerSize
                 )
             )
+        }
+        if (errorMessage != null) {
+            TempoTextFieldBaseErrorText(errorMessage)
         }
     }
 }

--- a/ui_components/src/main/java/com/enricog/ui_components/extensions/SecondsExtensions.kt
+++ b/ui_components/src/main/java/com/enricog/ui_components/extensions/SecondsExtensions.kt
@@ -1,0 +1,18 @@
+package com.enricog.ui_components.extensions
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import com.enricog.entities.Seconds
+import com.enricog.ui_components.R
+
+@Composable
+fun Seconds.format(): String {
+    return buildString {
+        if (minutes > 0) {
+            append("$minutes${stringResource(id = R.string.label_minutes_acronym)} ")
+        }
+        if (secondsRemainingInMinute > 0) {
+            append("$secondsRemainingInMinute${stringResource(id = R.string.label_seconds_acronym)}")
+        }
+    }
+}

--- a/ui_components/src/main/res/values/strings.xml
+++ b/ui_components/src/main/res/values/strings.xml
@@ -5,4 +5,7 @@
 
     <string name="label_minutes">min</string>
     <string name="label_seconds">secs</string>
+
+    <string name="label_minutes_acronym">m</string>
+    <string name="label_seconds_acronym">s</string>
 </resources>


### PR DESCRIPTION
This PR fixes:
- `TempoTimeField` error message that was showing doubled
- in every `SegmentItem` show a formatted duration instead of the value in seconds
- `TempoTextField` not updating correctly the state with the inserted value