### PR TITLE
Redesign detail segment screen

### DIFF
--- a/features/routines/src/main/java/com/enricog/features/routines/detail/segment/SegmentReducer.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/detail/segment/SegmentReducer.kt
@@ -64,6 +64,8 @@ internal class SegmentReducer @Inject constructor() {
     }
 
     fun updateSegmentTimeType(state: SegmentState.Data, timeType: TimeType): SegmentState.Data {
+        if (state.inputs.type == timeType) return state
+
         val time = if (timeType == TimeType.STOPWATCH) {
             "".timeText
         } else {

--- a/features/routines/src/main/java/com/enricog/features/routines/detail/segment/ui_components/SegmentFormScene.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/detail/segment/ui_components/SegmentFormScene.kt
@@ -9,11 +9,18 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.TextFieldValue
 import com.enricog.core.compose.api.extensions.stringResourceOrNull
 import com.enricog.core.compose.api.modifiers.swipeable.rememberSwipeableState
@@ -40,6 +47,9 @@ internal fun SegmentFormScene(
     onSegmentTimeTypeChange: (TimeType) -> Unit,
     onSegmentConfirmed: () -> Unit
 ) {
+    val keyboardController = LocalSoftwareKeyboardController.current
+    val (segmentNameRef, segmentTimeRef) = remember { FocusRequester.createRefs() }
+
     val swipeState = rememberSwipeableState(initialValue = segment.type) {
         onSegmentTimeTypeChange(it)
         true
@@ -72,10 +82,15 @@ internal fun SegmentFormScene(
                 onValueChange = onSegmentNameChange,
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(TempoTheme.dimensions.spaceM),
+                    .padding(TempoTheme.dimensions.spaceM)
+                    .focusRequester(segmentNameRef),
                 labelText = stringResource(R.string.field_label_segment_name),
                 errorText = stringResourceOrNull(id = errors[SegmentField.Name]?.stringResId),
-                singleLine = true
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
+                keyboardActions = KeyboardActions(
+                    onNext = { segmentTimeRef.requestFocus() }
+                )
             )
 
             SegmentPager(
@@ -86,7 +101,14 @@ internal fun SegmentFormScene(
                 selectedType = segment.type,
                 onSelectTimeTypeChange = onSegmentTimeTypeChange,
                 onTimeTextChange = onSegmentTimeChange,
-                errors = errors
+                errors = errors,
+                segmentTimeFieldIme = SegmentTimeFieldIme(
+                    action = ImeAction.Done,
+                    keyboardActions = KeyboardActions(
+                        onDone = { keyboardController?.hide() }
+                    ),
+                    focusRequester = segmentTimeRef
+                )
             )
         }
 

--- a/features/routines/src/main/java/com/enricog/features/routines/detail/segment/ui_components/SegmentFormScene.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/detail/segment/ui_components/SegmentFormScene.kt
@@ -95,7 +95,7 @@ internal fun SegmentFormScene(
                 .fillMaxWidth()
                 .padding(TempoTheme.dimensions.spaceM),
             onClick = onSegmentConfirmed,
-            color = TempoButtonColor.Confirm,
+            color = TempoButtonColor.Accent,
             text = stringResource(R.string.button_save),
             contentDescription = stringResource(R.string.content_description_button_save_segment)
         )

--- a/features/routines/src/main/java/com/enricog/features/routines/detail/segment/ui_components/SegmentPager.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/detail/segment/ui_components/SegmentPager.kt
@@ -26,6 +26,7 @@ internal fun SegmentPager(
     onSelectTimeTypeChange: (TimeType) -> Unit,
     onTimeTextChange: (TimeText) -> Unit,
     errors: Map<SegmentField, SegmentFieldError>,
+    segmentTimeFieldIme: SegmentTimeFieldIme,
     modifier: Modifier = Modifier
 ) = BoxWithConstraints(modifier = modifier) {
 
@@ -55,7 +56,8 @@ internal fun SegmentPager(
             anchors = timeFieldAnchors,
             timeText = timeText,
             onTimeTextChange = onTimeTextChange,
-            errors = errors
+            errors = errors,
+            timeFieldIme = segmentTimeFieldIme
         )
 
         Spacer(modifier = Modifier.height(TempoTheme.dimensions.spaceS))

--- a/features/routines/src/main/java/com/enricog/features/routines/detail/segment/ui_components/SegmentPager.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/detail/segment/ui_components/SegmentPager.kt
@@ -50,6 +50,16 @@ internal fun SegmentPager(
     Column(
         modifier = Modifier.fillMaxWidth()
     ) {
+        SegmentTimeField(
+            circleRadius = circleRadius,
+            anchors = timeFieldAnchors,
+            timeText = timeText,
+            onTimeTextChange = onTimeTextChange,
+            errors = errors
+        )
+
+        Spacer(modifier = Modifier.height(TempoTheme.dimensions.spaceS))
+
         SegmentTypeTabs(
             tabSpace,
             tabWidth,
@@ -59,16 +69,5 @@ internal fun SegmentPager(
             selectedType,
             onSelectTimeTypeChange
         )
-
-        Spacer(modifier = Modifier.height(TempoTheme.dimensions.spaceS))
-
-        SegmentTimeField(
-            circleRadius = circleRadius,
-            anchors = timeFieldAnchors,
-            timeText = timeText,
-            onTimeTextChange = onTimeTextChange,
-            errors = errors
-        )
     }
-
 }

--- a/features/routines/src/main/java/com/enricog/features/routines/detail/segment/ui_components/SegmentPager.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/detail/segment/ui_components/SegmentPager.kt
@@ -19,14 +19,14 @@ import kotlin.math.abs
 
 @Composable
 internal fun SegmentPager(
-    modifier: Modifier = Modifier,
     swipeState: SwipeableState<TimeType>,
     timeText: TimeText,
     timeTypes: List<TimeType>,
     selectedType: TimeType,
     onSelectTimeTypeChange: (TimeType) -> Unit,
     onTimeTextChange: (TimeText) -> Unit,
-    errors: Map<SegmentField, SegmentFieldError>
+    errors: Map<SegmentField, SegmentFieldError>,
+    modifier: Modifier = Modifier
 ) = BoxWithConstraints(modifier = modifier) {
 
     val circleRadius = maxWidth / 3
@@ -61,13 +61,13 @@ internal fun SegmentPager(
         Spacer(modifier = Modifier.height(TempoTheme.dimensions.spaceS))
 
         SegmentTypeTabs(
-            tabSpace,
-            tabWidth,
-            tabAnchors,
-            swipeState,
-            timeTypes,
-            selectedType,
-            onSelectTimeTypeChange
+            tabSpace = tabSpace,
+            tabWidth = tabWidth,
+            tabAnchors = tabAnchors,
+            swipeState = swipeState,
+            timeTypes = timeTypes,
+            selectedTimeType = selectedType,
+            onSelectTimeTypeChange = onSelectTimeTypeChange,
         )
     }
 }

--- a/features/routines/src/main/java/com/enricog/features/routines/detail/segment/ui_components/SegmentTimeField.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/detail/segment/ui_components/SegmentTimeField.kt
@@ -9,8 +9,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
@@ -33,10 +34,9 @@ internal fun SegmentTimeField(
     timeText: TimeText,
     onTimeTextChange: (TimeText) -> Unit,
     errors: Map<SegmentField, SegmentFieldError>,
+    timeFieldIme: SegmentTimeFieldIme,
     modifier: Modifier = Modifier
 ) {
-    val keyboardController = LocalSoftwareKeyboardController.current
-
     Box(
         modifier = modifier
             .fillMaxWidth()
@@ -56,12 +56,11 @@ internal fun SegmentTimeField(
             onValueChange = onTimeTextChange,
             modifier = Modifier
                 .padding(TempoTheme.dimensions.spaceM)
-                .align(Alignment.Center),
+                .align(Alignment.Center)
+                .focusRequester(timeFieldIme.focusRequester),
             errorText = stringResourceOrNull(errors[SegmentField.TimeInSeconds]?.stringResId),
-            imeAction = ImeAction.Done,
-            keyboardActions = KeyboardActions(
-                onDone = { keyboardController?.hide() }
-            ),
+            imeAction = timeFieldIme.action,
+            keyboardActions = timeFieldIme.keyboardActions,
             showBackground = false,
             showIndicator = false,
             textStyle = TextStyle(
@@ -72,3 +71,9 @@ internal fun SegmentTimeField(
         )
     }
 }
+
+internal data class SegmentTimeFieldIme(
+    val action: ImeAction,
+    val keyboardActions: KeyboardActions,
+    val focusRequester: FocusRequester
+)

--- a/features/routines/src/main/java/com/enricog/features/routines/detail/segment/ui_components/SegmentTimeField.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/detail/segment/ui_components/SegmentTimeField.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -12,8 +11,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.sp
 import com.enricog.core.compose.api.extensions.stringResourceOrNull
 import com.enricog.data.routines.api.entities.TimeType
 import com.enricog.features.routines.detail.segment.models.SegmentField
@@ -52,14 +55,19 @@ internal fun SegmentTimeField(
             value = timeText,
             onValueChange = onTimeTextChange,
             modifier = Modifier
-                .width(width = circleRadius)
-                .height(height = circleRadius)
                 .padding(TempoTheme.dimensions.spaceM)
                 .align(Alignment.Center),
             errorText = stringResourceOrNull(errors[SegmentField.TimeInSeconds]?.stringResId),
             imeAction = ImeAction.Done,
             keyboardActions = KeyboardActions(
                 onDone = { keyboardController?.hide() }
+            ),
+            showBackground = false,
+            showIndicator = false,
+            textStyle = TextStyle(
+                fontSize = 73.sp,
+                textAlign = TextAlign.Center,
+                fontWeight = FontWeight.Bold
             )
         )
     }

--- a/features/routines/src/main/java/com/enricog/features/routines/detail/segment/ui_components/SegmentTypeTab.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/detail/segment/ui_components/SegmentTypeTab.kt
@@ -9,7 +9,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
@@ -24,23 +23,18 @@ internal const val SegmentTypeTabTestTag = "SegmentTypeTabTestTag"
 @Composable
 internal fun SegmentTypeTab(
     value: TimeType,
-    isSelected: Boolean,
+    onClick: (TimeType) -> Unit,
     modifier: Modifier = Modifier,
-    onClick: ((TimeType) -> Unit)? = null
 ) {
     Box(
         modifier = modifier
             .testTag(SegmentTypeTabTestTag)
             .clip(shape = RoundedCornerShape(percent = 50))
-            .clickable(enabled = onClick != null) {
-                if (!isSelected) {
-                    onClick?.invoke(value)
-                }
-            },
+            .clickable { onClick(value) },
         contentAlignment = Alignment.Center
     ) {
         TempoText(
-            text = AnnotatedString(value.text()),
+            text = value.text(),
             style = TextStyle(
                 color = white,
                 fontWeight = FontWeight.Bold,

--- a/features/routines/src/main/java/com/enricog/features/routines/detail/segment/ui_components/SegmentTypeTabs.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/detail/segment/ui_components/SegmentTypeTabs.kt
@@ -46,7 +46,7 @@ internal fun SegmentTypeTabs(
                     color = selectedTimeType.color(),
                     cornerRadius = CornerRadius(x = 50f, y = 50f),
                     topLeft = Offset(x = swipeState.offset.value, y = tabSpace.toPx()),
-                    size = Size(width = tabWidth.toPx(), height = 90f)
+                    size = Size(width = tabWidth.toPx(), height = 85f)
                 )
             }
     ) {
@@ -67,7 +67,6 @@ internal fun SegmentTypeTabs(
             timeTypes.mapIndexed { index, timeType ->
                 SegmentTypeTab(
                     value = timeType,
-                    isSelected = false,
                     onClick = {
                         coroutineScope.launch {
                             onSelectTimeTypeChange(it)

--- a/features/routines/src/main/java/com/enricog/features/routines/detail/summary/ui_components/SegmentItem.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/detail/summary/ui_components/SegmentItem.kt
@@ -64,8 +64,7 @@ internal fun SegmentItem(
                         bottom.linkTo(parent.bottom)
                     }
                     .padding(top = TempoTheme.dimensions.spaceM),
-                value = segment.type,
-                isSelected = true
+                value = segment.type
             )
 
             TempoText(

--- a/features/routines/src/main/java/com/enricog/features/routines/detail/ui/time_type/TimeTypeChip.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/detail/ui/time_type/TimeTypeChip.kt
@@ -1,16 +1,13 @@
 package com.enricog.features.routines.detail.ui.time_type
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
@@ -18,7 +15,6 @@ import androidx.compose.ui.unit.sp
 import com.enricog.data.routines.api.entities.TimeType
 import com.enricog.ui.components.text.TempoText
 import com.enricog.ui.theme.TempoTheme
-import com.enricog.ui.theme.darkBlue500
 import com.enricog.ui.theme.white
 
 internal const val TimeTypeChipTestTag = "TimeTypeChipTestTag"
@@ -27,21 +23,13 @@ private val chipShape = RoundedCornerShape(percent = 50)
 @Composable
 internal fun TimeTypeChip(
     value: TimeType,
-    isSelected: Boolean,
-    modifier: Modifier = Modifier,
-    onClick: ((TimeType) -> Unit)? = null
+    modifier: Modifier = Modifier
 ) {
     Box(
         modifier = modifier
             .testTag(TimeTypeChipTestTag)
-            .alpha(if (isSelected) 1f else 0.7f)
             .clip(chipShape)
-            .background(color = value.color(isSelected), shape = chipShape)
-            .clickable(enabled = onClick != null) {
-                if (!isSelected) {
-                    onClick?.invoke(value)
-                }
-            },
+            .background(color = value.color(), shape = chipShape),
         contentAlignment = Alignment.Center
     ) {
         TempoText(
@@ -57,9 +45,4 @@ internal fun TimeTypeChip(
             )
         )
     }
-}
-
-private fun TimeType.color(isSelected: Boolean): Color {
-    if (!isSelected) return darkBlue500
-    return color()
 }

--- a/features/routines/src/test/java/com/enricog/features/routines/detail/segment/SegmentReducerTest.kt
+++ b/features/routines/src/test/java/com/enricog/features/routines/detail/segment/SegmentReducerTest.kt
@@ -105,7 +105,10 @@ class SegmentReducerTest {
             )
         )
 
-        val actual = sut.updateSegmentName(state = state, textFieldValue = "Segment Name Modified".toTextFieldValue())
+        val actual = sut.updateSegmentName(
+            state = state,
+            textFieldValue = "Segment Name Modified".toTextFieldValue()
+        )
 
         assertEquals(expected, actual)
     }
@@ -196,6 +199,30 @@ class SegmentReducerTest {
         )
 
         val actual = sut.updateSegmentTime(state = state, text = "10".timeText)
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should not update segment type when same segment type is selected`() {
+        val expected = SegmentState.Data(
+            routine = Routine.EMPTY.copy(
+                segments = emptyList()
+            ),
+            segment = Segment.EMPTY.copy(
+                type = TimeType.TIMER,
+                time = 10.seconds
+            ),
+            errors = emptyMap(),
+            timeTypes = listOf(TimeType.TIMER, TimeType.REST, TimeType.STOPWATCH),
+            inputs = SegmentInputs(
+                name = "Segment Name".toTextFieldValue(),
+                time = "10".timeText,
+                type = TimeType.TIMER
+            )
+        )
+
+        val actual = sut.updateSegmentTimeType(state = expected, timeType = TimeType.TIMER)
 
         assertEquals(expected, actual)
     }

--- a/ui/components/src/main/java/com/enricog/ui/components/textField/TempoTextField.kt
+++ b/ui/components/src/main/java/com/enricog/ui/components/textField/TempoTextField.kt
@@ -4,9 +4,11 @@ import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.tooling.preview.Preview
+import com.enricog.ui.theme.TempoTheme
 
 @Composable
 fun TempoTextField(
@@ -16,6 +18,7 @@ fun TempoTextField(
     labelText: String? = null,
     supportingText: String? = null,
     errorText: String? = null,
+    textStyle: TextStyle = TempoTheme.typography.textField,
     leadingIcon: @Composable (() -> Unit)? = null,
     trailingIcon: @Composable (() -> Unit)? = null,
     visualTransformation: VisualTransformation = VisualTransformation.None,
@@ -23,6 +26,8 @@ fun TempoTextField(
     keyboardActions: KeyboardActions = KeyboardActions.Default,
     singleLine: Boolean = false,
     maxLines: Int = Int.MAX_VALUE,
+    showBackground: Boolean = true,
+    showIndicator: Boolean = true
 ) {
     require(errorText == null || errorText.isNotBlank()) { "Error text cannot be blank" }
     require(labelText == null || labelText.isNotBlank()) { "Label text cannot be blank" }
@@ -41,7 +46,10 @@ fun TempoTextField(
         keyboardOptions = keyboardOptions,
         keyboardActions = keyboardActions,
         singleLine = singleLine,
-        maxLines = maxLines
+        maxLines = maxLines,
+        textStyle = textStyle,
+        showBackground = showBackground,
+        showIndicator = showIndicator
     )
 }
 

--- a/ui/components/src/main/java/com/enricog/ui/components/textField/TempoTextFieldBase.kt
+++ b/ui/components/src/main/java/com/enricog/ui/components/textField/TempoTextFieldBase.kt
@@ -22,6 +22,7 @@ import androidx.compose.material.TextField
 import androidx.compose.material.TextFieldColors
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -45,7 +46,6 @@ import com.enricog.ui.theme.TempoTheme
 internal fun TempoTextFieldBase(
     value: TextFieldValue,
     onValueChange: (TextFieldValue) -> Unit,
-    modifier: Modifier,
     labelText: String?,
     supportingText: String?,
     errorText: String?,
@@ -55,7 +55,11 @@ internal fun TempoTextFieldBase(
     keyboardOptions: KeyboardOptions,
     keyboardActions: KeyboardActions,
     singleLine: Boolean,
-    maxLines: Int
+    maxLines: Int,
+    modifier: Modifier = Modifier,
+    textStyle: TextStyle = TempoTextFieldBaseDefaults.textStyle,
+    showBackground: Boolean = true,
+    showIndicator: Boolean = true,
 ) {
     require(errorText == null || errorText.isNotBlank()) { "Error text cannot be blank" }
     require(labelText == null || labelText.isNotBlank()) { "Label text cannot be blank" }
@@ -103,7 +107,7 @@ internal fun TempoTextFieldBase(
                 .clip(shape)
                 .fillMaxSize()
                 .semantics { if (isError) error(requireNotNull(errorText)) },
-            textStyle = TempoTextFieldBaseDefaults.textStyle,
+            textStyle = TempoTextFieldBaseDefaults.textStyle.merge(textStyle),
             label = label,
             leadingIcon = leadingIcon,
             trailingIcon = trailingIcon,
@@ -114,7 +118,10 @@ internal fun TempoTextFieldBase(
             singleLine = singleLine,
             maxLines = maxLines,
             shape = shape,
-            colors = TempoTextFieldBaseColors,
+            colors = TempoTextFieldBaseDefaults.fieldColors(
+                showBackground = showBackground,
+                showIndicator = showIndicator
+            ),
             interactionSource = interactionSource
         )
         Box(
@@ -172,6 +179,9 @@ private fun TempoTextFieldBaseLabelText(label: String, fontSize: TextUnit) {
 
 private object TempoTextFieldBaseDefaults {
 
+    private const val BackgroundOpacity = 0.06f
+    private const val UnfocusedIndicatorLineOpacity = 0.30f
+
     val shape: Shape
         @Composable
         get() = TempoTheme.shapes.textField
@@ -181,24 +191,98 @@ private object TempoTextFieldBaseDefaults {
         get() = TempoTheme.typography.textField
 
     val labelTextSizeTransitionSpec: FiniteAnimationSpec<Int> = spring(visibilityThreshold = 1)
+
+    @Composable
+    fun fieldColors(showBackground: Boolean, showIndicator: Boolean): TextFieldColors {
+        return TempoTextFieldBaseColors(
+            // Background
+            backgroundColor = TempoTheme.colors.onSurface
+                .copy(alpha = if (showBackground) BackgroundOpacity else 0f),
+            // Cursor
+            cursorDefaultColor = TempoTheme.colors.primary,
+            cursorErrorColor = TempoTheme.colors.error,
+            // Indicator
+            indicatorFocusedColor = TempoTheme.colors.primary
+                .copy(alpha = if (showIndicator) ContentAlpha.high else 0f),
+            indicatorUnfocusedColor = TempoTheme.colors.onSurface
+                .copy(alpha = if (showIndicator) UnfocusedIndicatorLineOpacity else 0f),
+            indicatorDisabledColor = TempoTheme.colors.onSurface
+                .copy(alpha = if (showIndicator) ContentAlpha.disabled else 0f),
+            indicatorErrorColor = TempoTheme.colors.error
+                .copy(alpha = if (showIndicator) 1f else 0f),
+            // Label
+            labelFocusedColor = TempoTheme.colors.onSurface
+                .copy(alpha = ContentAlpha.high),
+            labelUnfocusedColor = TempoTheme.colors.onSurface
+                .copy(alpha = ContentAlpha.medium),
+            labelDisabledColor = TempoTheme.colors.onSurface
+                .copy(alpha = ContentAlpha.disabled),
+            labelErrorColor = TempoTheme.colors.onSurface
+                .copy(alpha = ContentAlpha.high),
+            // Placeholder
+            placeholderColor = TempoTheme.colors.onSurface
+                .copy(alpha = ContentAlpha.medium),
+            placeholderDisabledColor = TempoTheme.colors.onSurface
+                .copy(alpha = ContentAlpha.disabled),
+            // Text
+            textColor = TempoTheme.colors.onSurface
+                .copy(alpha = 1f),
+            textDisabledColor = TempoTheme.colors.onSurface
+                .copy(alpha = ContentAlpha.disabled),
+            // Leading Icon
+            leadingIconColor = TempoTheme.colors.onSurface
+                .copy(alpha = 0.54f),
+            leadingIconDisabledColor = TempoTheme.colors.onSurface
+                .copy(alpha = ContentAlpha.disabled),
+            // Trailing Icon
+            trailingIconColor = TempoTheme.colors.onSurface
+                .copy(alpha = 0.54f),
+            trailingIconDisabledColor = TempoTheme.colors.onSurface
+                .copy(alpha = ContentAlpha.disabled),
+            trailingIconErrorColor = TempoTheme.colors.error,
+        )
+    }
 }
 
-private object TempoTextFieldBaseColors : TextFieldColors {
-
-    private const val BackgroundOpacity = 0.06f
-    private const val UnfocusedIndicatorLineOpacity = 0.30f
+@Immutable
+private class TempoTextFieldBaseColors(
+    // Background
+    private val backgroundColor: Color,
+    // Cursor
+    private val cursorDefaultColor: Color,
+    private val cursorErrorColor: Color,
+    // Indicator
+    private val indicatorFocusedColor: Color,
+    private val indicatorUnfocusedColor: Color,
+    private val indicatorDisabledColor: Color,
+    private val indicatorErrorColor: Color,
+    // Label
+    private val labelFocusedColor: Color,
+    private val labelUnfocusedColor: Color,
+    private val labelDisabledColor: Color,
+    private val labelErrorColor: Color,
+    // Placeholder
+    private val placeholderColor: Color,
+    private val placeholderDisabledColor: Color,
+    // Text
+    private val textColor: Color,
+    private val textDisabledColor: Color,
+    // Leading Icon
+    private val leadingIconColor: Color,
+    private val leadingIconDisabledColor: Color,
+    // Trailing Icon
+    private val trailingIconColor: Color,
+    private val trailingIconDisabledColor: Color,
+    private val trailingIconErrorColor: Color,
+) : TextFieldColors {
 
     @Composable
     override fun backgroundColor(enabled: Boolean): State<Color> {
-        val backgroundColor = TempoTheme.colors.onSurface
-            .copy(alpha = BackgroundOpacity)
         return rememberUpdatedState(backgroundColor)
     }
 
     @Composable
     override fun cursorColor(isError: Boolean): State<Color> {
-        val cursorDefaultColor = TempoTheme.colors.primary
-        val cursorErrorColor = TempoTheme.colors.error
         return rememberUpdatedState(if (isError) cursorErrorColor else cursorDefaultColor)
     }
 
@@ -208,14 +292,6 @@ private object TempoTextFieldBaseColors : TextFieldColors {
         isError: Boolean,
         interactionSource: InteractionSource
     ): State<Color> {
-        val indicatorFocusedColor = TempoTheme.colors.primary
-            .copy(alpha = ContentAlpha.high)
-        val indicatorUnfocusedColor = TempoTheme.colors.onSurface
-            .copy(alpha = UnfocusedIndicatorLineOpacity)
-        val indicatorDisabledColor = indicatorUnfocusedColor
-            .copy(alpha = ContentAlpha.disabled)
-        val indicatorErrorColor = TempoTheme.colors.error
-
         val focused by interactionSource.collectIsFocusedAsState()
 
         val targetValue = when {
@@ -240,15 +316,6 @@ private object TempoTextFieldBaseColors : TextFieldColors {
         error: Boolean,
         interactionSource: InteractionSource
     ): State<Color> {
-        val labelFocusedColor = TempoTheme.colors.onSurface
-            .copy(alpha = ContentAlpha.high)
-        val labelUnfocusedColor = TempoTheme.colors.onSurface
-            .copy(alpha = ContentAlpha.medium)
-        val labelDisabledColor = labelUnfocusedColor
-            .copy(alpha = ContentAlpha.disabled)
-        val labelErrorColor = TempoTheme.colors.onSurface
-            .copy(alpha = ContentAlpha.high)
-
         val focused by interactionSource.collectIsFocusedAsState()
 
         val targetValue = when {
@@ -262,29 +329,16 @@ private object TempoTextFieldBaseColors : TextFieldColors {
 
     @Composable
     override fun placeholderColor(enabled: Boolean): State<Color> {
-        val placeholderColor = TempoTheme.colors.onSurface
-            .copy(alpha = ContentAlpha.medium)
-        val placeholderDisabledColor = placeholderColor
-            .copy(alpha = ContentAlpha.disabled)
-
         return rememberUpdatedState(if (enabled) placeholderColor else placeholderDisabledColor)
     }
 
     @Composable
     override fun textColor(enabled: Boolean): State<Color> {
-        val textColor = TempoTheme.colors.onSurface.copy(alpha = 1f)
-        val textDisabledColor = textColor.copy(alpha = ContentAlpha.disabled)
-
         return rememberUpdatedState(if (enabled) textColor else textDisabledColor)
     }
 
     @Composable
     override fun leadingIconColor(enabled: Boolean, isError: Boolean): State<Color> {
-        val leadingIconColor = TempoTheme.colors.onSurface
-            .copy(alpha = 0.54f)
-        val leadingIconDisabledColor = leadingIconColor
-            .copy(alpha = ContentAlpha.disabled)
-
         return rememberUpdatedState(
             when {
                 !enabled -> leadingIconDisabledColor
@@ -296,12 +350,6 @@ private object TempoTextFieldBaseColors : TextFieldColors {
 
     @Composable
     override fun trailingIconColor(enabled: Boolean, isError: Boolean): State<Color> {
-        val trailingIconColor = TempoTheme.colors.onSurface
-            .copy(alpha = 0.54f)
-        val trailingIconDisabledColor = trailingIconColor
-            .copy(alpha = ContentAlpha.disabled)
-        val trailingIconErrorColor = TempoTheme.colors.error
-
         return rememberUpdatedState(
             when {
                 !enabled -> trailingIconDisabledColor
@@ -310,6 +358,62 @@ private object TempoTextFieldBaseColors : TextFieldColors {
             }
         )
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as TempoTextFieldBaseColors
+
+        if (backgroundColor != other.backgroundColor) return false
+        if (cursorDefaultColor != other.cursorDefaultColor) return false
+        if (cursorErrorColor != other.cursorErrorColor) return false
+        if (indicatorFocusedColor != other.indicatorFocusedColor) return false
+        if (indicatorUnfocusedColor != other.indicatorUnfocusedColor) return false
+        if (indicatorDisabledColor != other.indicatorDisabledColor) return false
+        if (indicatorErrorColor != other.indicatorErrorColor) return false
+        if (labelFocusedColor != other.labelFocusedColor) return false
+        if (labelUnfocusedColor != other.labelUnfocusedColor) return false
+        if (labelDisabledColor != other.labelDisabledColor) return false
+        if (labelErrorColor != other.labelErrorColor) return false
+        if (placeholderColor != other.placeholderColor) return false
+        if (placeholderDisabledColor != other.placeholderDisabledColor) return false
+        if (textColor != other.textColor) return false
+        if (textDisabledColor != other.textDisabledColor) return false
+        if (leadingIconColor != other.leadingIconColor) return false
+        if (leadingIconDisabledColor != other.leadingIconDisabledColor) return false
+        if (trailingIconColor != other.trailingIconColor) return false
+        if (trailingIconDisabledColor != other.trailingIconDisabledColor) return false
+        if (trailingIconErrorColor != other.trailingIconErrorColor) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = backgroundColor.hashCode()
+        result = 31 * result + cursorDefaultColor.hashCode()
+        result = 31 * result + cursorErrorColor.hashCode()
+        result = 31 * result + indicatorFocusedColor.hashCode()
+        result = 31 * result + indicatorUnfocusedColor.hashCode()
+        result = 31 * result + indicatorDisabledColor.hashCode()
+        result = 31 * result + indicatorErrorColor.hashCode()
+        result = 31 * result + labelFocusedColor.hashCode()
+        result = 31 * result + labelUnfocusedColor.hashCode()
+        result = 31 * result + labelDisabledColor.hashCode()
+        result = 31 * result + labelErrorColor.hashCode()
+        result = 31 * result + placeholderColor.hashCode()
+        result = 31 * result + placeholderDisabledColor.hashCode()
+        result = 31 * result + textColor.hashCode()
+        result = 31 * result + textDisabledColor.hashCode()
+        result = 31 * result + leadingIconColor.hashCode()
+        result = 31 * result + leadingIconDisabledColor.hashCode()
+        result = 31 * result + trailingIconColor.hashCode()
+        result = 31 * result + trailingIconDisabledColor.hashCode()
+        result = 31 * result + trailingIconErrorColor.hashCode()
+        return result
+    }
+
+
 }
 
 private enum class InputPhase {

--- a/ui/components/src/main/java/com/enricog/ui/components/textField/TempoTimeField.kt
+++ b/ui/components/src/main/java/com/enricog/ui/components/textField/TempoTimeField.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.OffsetMapping
@@ -14,6 +15,7 @@ import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.input.TransformedText
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.tooling.preview.Preview
+import com.enricog.ui.theme.TempoTheme
 
 private val NUMERIC_REGEX = Regex("^[0-9]+\$|^\$|^\\s\$")
 
@@ -25,8 +27,11 @@ fun TempoTimeField(
     labelText: String? = null,
     supportingText: String? = null,
     errorText: String? = null,
+    textStyle: TextStyle = TempoTheme.typography.textField,
     imeAction: ImeAction = ImeAction.Default,
-    keyboardActions: KeyboardActions = KeyboardActions.Default
+    keyboardActions: KeyboardActions = KeyboardActions.Default,
+    showBackground: Boolean = true,
+    showIndicator: Boolean = true
 ) {
     require(errorText == null || errorText.isNotBlank()) { "Error text cannot be blank" }
     require(labelText == null || labelText.isNotBlank()) { "Label text cannot be blank" }
@@ -58,7 +63,10 @@ fun TempoTimeField(
         keyboardActions = keyboardActions,
         singleLine = true,
         maxLines = 1,
-        visualTransformation = TimeVisualTransformation
+        visualTransformation = TimeVisualTransformation,
+        textStyle = textStyle,
+        showBackground = showBackground,
+        showIndicator = showIndicator
     )
 }
 


### PR DESCRIPTION
Little UI review of the detail segment screen

- Add support of `textStyle`, `showBackground` and `showIndicator` in the `TempoTextFieldBase`
- Review `SegmentTimeField` to be displayed without background and indicator. Customized text size as well.
- Handle fields keyboard ime actions in segment screen