### PR TITLE
Fix: Show segment time error

### DIFF
--- a/features/routines/src/main/java/com/enricog/features/routines/detail/segment/SegmentReducer.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/detail/segment/SegmentReducer.kt
@@ -42,10 +42,7 @@ internal class SegmentReducer @Inject constructor() {
     ): SegmentState.Data {
         val inputs = state.inputs.copy(name = textFieldValue)
         val errors = state.errors.filterKeys { it != SegmentField.Name }
-        return state.copy(
-            inputs = inputs,
-            errors = errors
-        )
+        return state.copy(inputs = inputs, errors = errors)
     }
 
     fun updateSegmentTime(state: SegmentState.Data, text: TimeText): SegmentState.Data {
@@ -56,11 +53,8 @@ internal class SegmentReducer @Inject constructor() {
         }
 
         val inputs = state.inputs.copy(time = time)
-        val errors = state.errors.filterKeys { it != SegmentField.TimeInSeconds }
-        return state.copy(
-            inputs = inputs,
-            errors = errors
-        )
+        val errors = state.errors.filterKeys { it != SegmentField.Time }
+        return state.copy(inputs = inputs, errors = errors)
     }
 
     fun updateSegmentTimeType(state: SegmentState.Data, timeType: TimeType): SegmentState.Data {
@@ -72,11 +66,9 @@ internal class SegmentReducer @Inject constructor() {
             state.inputs.time
         }
 
-        val inputs = state.inputs.copy(
-            type = timeType,
-            time = time
-        )
-        return state.copy(inputs = inputs)
+        val inputs = state.inputs.copy(type = timeType, time = time)
+        val errors = state.errors.filterKeys { it != SegmentField.Time }
+        return state.copy(inputs = inputs, errors = errors)
     }
 
     fun applySegmentErrors(

--- a/features/routines/src/main/java/com/enricog/features/routines/detail/segment/SegmentValidator.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/detail/segment/SegmentValidator.kt
@@ -16,7 +16,7 @@ internal class SegmentValidator @Inject constructor() {
             }
             val seconds = inputs.time.toSeconds()
             if (seconds <= 0.seconds && inputs.type != TimeType.STOPWATCH) {
-                put(SegmentField.TimeInSeconds, SegmentFieldError.InvalidSegmentTime)
+                put(SegmentField.Time, SegmentFieldError.InvalidSegmentTime)
             }
         }
     }

--- a/features/routines/src/main/java/com/enricog/features/routines/detail/segment/models/SegmentField.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/detail/segment/models/SegmentField.kt
@@ -1,5 +1,5 @@
 package com.enricog.features.routines.detail.segment.models
 
 internal enum class SegmentField {
-    Name, TimeInSeconds
+    Name, Time
 }

--- a/features/routines/src/main/java/com/enricog/features/routines/detail/segment/ui_components/SegmentPager.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/detail/segment/ui_components/SegmentPager.kt
@@ -2,17 +2,20 @@ package com.enricog.features.routines.detail.segment.ui_components
 
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.enricog.core.compose.api.extensions.stringResourceOrNull
 import com.enricog.core.compose.api.extensions.toPx
 import com.enricog.core.compose.api.modifiers.swipeable.SwipeableState
 import com.enricog.data.routines.api.entities.TimeType
 import com.enricog.features.routines.detail.segment.models.SegmentField
 import com.enricog.features.routines.detail.segment.models.SegmentFieldError
+import com.enricog.ui.components.text.TempoText
 import com.enricog.ui.components.textField.TimeText
 import com.enricog.ui.theme.TempoTheme
 import kotlin.math.abs
@@ -29,6 +32,8 @@ internal fun SegmentPager(
     segmentTimeFieldIme: SegmentTimeFieldIme,
     modifier: Modifier = Modifier
 ) = BoxWithConstraints(modifier = modifier) {
+
+    val errorMessage = stringResourceOrNull(errors[SegmentField.TimeInSeconds]?.stringResId) ?: ""
 
     val circleRadius = maxWidth / 3
     val center = maxWidth / 2
@@ -56,11 +61,20 @@ internal fun SegmentPager(
             anchors = timeFieldAnchors,
             timeText = timeText,
             onTimeTextChange = onTimeTextChange,
-            errors = errors,
             timeFieldIme = segmentTimeFieldIme
         )
 
-        Spacer(modifier = Modifier.height(TempoTheme.dimensions.spaceS))
+        TempoText(
+            modifier = Modifier
+                .height(35.dp)
+                .padding(vertical = TempoTheme.dimensions.spaceS)
+                .align(alignment = Alignment.CenterHorizontally),
+            text = errorMessage,
+            style = TempoTheme.typography.caption.copy(
+                color = TempoTheme.colors.error
+            ),
+            maxLines = 1
+        )
 
         SegmentTypeTabs(
             tabSpace = tabSpace,

--- a/features/routines/src/main/java/com/enricog/features/routines/detail/segment/ui_components/SegmentPager.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/detail/segment/ui_components/SegmentPager.kt
@@ -33,7 +33,7 @@ internal fun SegmentPager(
     modifier: Modifier = Modifier
 ) = BoxWithConstraints(modifier = modifier) {
 
-    val errorMessage = stringResourceOrNull(errors[SegmentField.TimeInSeconds]?.stringResId) ?: ""
+    val errorMessage = stringResourceOrNull(errors[SegmentField.Time]?.stringResId) ?: ""
 
     val circleRadius = maxWidth / 3
     val center = maxWidth / 2

--- a/features/routines/src/main/java/com/enricog/features/routines/detail/segment/ui_components/SegmentTimeField.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/detail/segment/ui_components/SegmentTimeField.kt
@@ -1,6 +1,6 @@
 package com.enricog.features.routines.detail.segment.ui_components
 
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -18,10 +18,7 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.sp
-import com.enricog.core.compose.api.extensions.stringResourceOrNull
 import com.enricog.data.routines.api.entities.TimeType
-import com.enricog.features.routines.detail.segment.models.SegmentField
-import com.enricog.features.routines.detail.segment.models.SegmentFieldError
 import com.enricog.features.routines.detail.ui.time_type.color
 import com.enricog.ui.components.textField.TempoTimeField
 import com.enricog.ui.components.textField.TimeText
@@ -33,11 +30,10 @@ internal fun SegmentTimeField(
     anchors: Map<TimeType, Float>,
     timeText: TimeText,
     onTimeTextChange: (TimeText) -> Unit,
-    errors: Map<SegmentField, SegmentFieldError>,
     timeFieldIme: SegmentTimeFieldIme,
     modifier: Modifier = Modifier
 ) {
-    Box(
+    Row(
         modifier = modifier
             .fillMaxWidth()
             .height(height = circleRadius * 2)
@@ -56,9 +52,8 @@ internal fun SegmentTimeField(
             onValueChange = onTimeTextChange,
             modifier = Modifier
                 .padding(TempoTheme.dimensions.spaceM)
-                .align(Alignment.Center)
+                .align(Alignment.CenterVertically)
                 .focusRequester(timeFieldIme.focusRequester),
-            errorText = stringResourceOrNull(errors[SegmentField.TimeInSeconds]?.stringResId),
             imeAction = timeFieldIme.action,
             keyboardActions = timeFieldIme.keyboardActions,
             showBackground = false,

--- a/features/routines/src/test/java/com/enricog/features/routines/detail/segment/SegmentReducerTest.kt
+++ b/features/routines/src/test/java/com/enricog/features/routines/detail/segment/SegmentReducerTest.kt
@@ -80,7 +80,7 @@ class SegmentReducerTest {
             segment = Segment.EMPTY.copy(name = "Segment Name"),
             errors = mapOf(
                 SegmentField.Name to SegmentFieldError.BlankSegmentName,
-                SegmentField.TimeInSeconds to SegmentFieldError.InvalidSegmentTime
+                SegmentField.Time to SegmentFieldError.InvalidSegmentTime
             ),
             timeTypes = listOf(TimeType.TIMER, TimeType.REST, TimeType.STOPWATCH),
             inputs = SegmentInputs(
@@ -95,7 +95,7 @@ class SegmentReducerTest {
             ),
             segment = Segment.EMPTY.copy(name = "Segment Name"),
             errors = mapOf(
-                SegmentField.TimeInSeconds to SegmentFieldError.InvalidSegmentTime
+                SegmentField.Time to SegmentFieldError.InvalidSegmentTime
             ),
             timeTypes = listOf(TimeType.TIMER, TimeType.REST, TimeType.STOPWATCH),
             inputs = SegmentInputs(
@@ -125,7 +125,7 @@ class SegmentReducerTest {
             ),
             errors = mapOf(
                 SegmentField.Name to SegmentFieldError.BlankSegmentName,
-                SegmentField.TimeInSeconds to SegmentFieldError.InvalidSegmentTime
+                SegmentField.Time to SegmentFieldError.InvalidSegmentTime
             ),
             timeTypes = listOf(TimeType.TIMER, TimeType.REST, TimeType.STOPWATCH),
             inputs = SegmentInputs(
@@ -170,7 +170,7 @@ class SegmentReducerTest {
             ),
             errors = mapOf(
                 SegmentField.Name to SegmentFieldError.BlankSegmentName,
-                SegmentField.TimeInSeconds to SegmentFieldError.InvalidSegmentTime
+                SegmentField.Time to SegmentFieldError.InvalidSegmentTime
             ),
             timeTypes = listOf(TimeType.TIMER, TimeType.REST, TimeType.STOPWATCH),
             inputs = SegmentInputs(
@@ -268,6 +268,51 @@ class SegmentReducerTest {
     }
 
     @Test
+    fun `should clear time error when selected type is selected`() {
+        val state = SegmentState.Data(
+            routine = Routine.EMPTY.copy(
+                segments = emptyList()
+            ),
+            segment = Segment.EMPTY.copy(
+                type = TimeType.TIMER,
+                time = 10.seconds
+            ),
+            errors = mapOf(
+                SegmentField.Name to SegmentFieldError.BlankSegmentName,
+                SegmentField.Time to SegmentFieldError.InvalidSegmentTime,
+            ),
+            timeTypes = listOf(TimeType.TIMER, TimeType.REST, TimeType.STOPWATCH),
+            inputs = SegmentInputs(
+                name = "".toTextFieldValue(),
+                time = "10".timeText,
+                type = TimeType.TIMER
+            )
+        )
+        val expected = SegmentState.Data(
+            routine = Routine.EMPTY.copy(
+                segments = emptyList()
+            ),
+            segment = Segment.EMPTY.copy(
+                time = 10.seconds,
+                type = TimeType.TIMER
+            ),
+            errors = mapOf(
+                SegmentField.Name to SegmentFieldError.BlankSegmentName,
+            ),
+            timeTypes = listOf(TimeType.TIMER, TimeType.REST, TimeType.STOPWATCH),
+            inputs = SegmentInputs(
+                name = "".toTextFieldValue(),
+                time = "10".timeText,
+                type = TimeType.REST
+            )
+        )
+
+        val actual = sut.updateSegmentTimeType(state = state, timeType = TimeType.REST)
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
     fun `should update segment type and set segment time to zero when selected type not TimeType#STOPWATCH`() {
         val state = SegmentState.Data(
             routine = Routine.EMPTY.copy(
@@ -311,7 +356,7 @@ class SegmentReducerTest {
     fun `should apply segment errors`() {
         val errors = mapOf(
             SegmentField.Name to SegmentFieldError.BlankSegmentName,
-            SegmentField.TimeInSeconds to SegmentFieldError.InvalidSegmentTime
+            SegmentField.Time to SegmentFieldError.InvalidSegmentTime
         )
         val state = SegmentState.Data(
             routine = Routine.EMPTY,

--- a/features/routines/src/test/java/com/enricog/features/routines/detail/segment/SegmentStateConverterTest.kt
+++ b/features/routines/src/test/java/com/enricog/features/routines/detail/segment/SegmentStateConverterTest.kt
@@ -41,7 +41,7 @@ class SegmentStateConverterTest {
             segment = Segment.EMPTY,
             errors = mapOf(
                 SegmentField.Name to SegmentFieldError.BlankSegmentName,
-                SegmentField.TimeInSeconds to SegmentFieldError.InvalidSegmentTime
+                SegmentField.Time to SegmentFieldError.InvalidSegmentTime
             ),
             timeTypes = emptyList(),
             inputs = SegmentInputs(
@@ -58,7 +58,7 @@ class SegmentStateConverterTest {
             ),
             errors = mapOf(
                 SegmentField.Name to SegmentFieldError.BlankSegmentName,
-                SegmentField.TimeInSeconds to SegmentFieldError.InvalidSegmentTime
+                SegmentField.Time to SegmentFieldError.InvalidSegmentTime
             ),
             timeTypes = emptyList()
         )

--- a/features/routines/src/test/java/com/enricog/features/routines/detail/segment/SegmentValidatorTest.kt
+++ b/features/routines/src/test/java/com/enricog/features/routines/detail/segment/SegmentValidatorTest.kt
@@ -35,7 +35,7 @@ class SegmentValidatorTest {
             type = TimeType.TIMER
         )
         val expected = mapOf<SegmentField, SegmentFieldError>(
-            SegmentField.TimeInSeconds to SegmentFieldError.InvalidSegmentTime
+            SegmentField.Time to SegmentFieldError.InvalidSegmentTime
         )
 
         val actual = sut.validate(inputs = inputs)


### PR DESCRIPTION
In the segment detail, if the time has an error the message was not displayed:
- Add `TempoText` to show the time error message in the segment detail screen
- The time error is cleared when the time type changes