### PR TITLE
Testing: Flow test eager

### DIFF
--- a/core/coroutines/testing/src/main/java/com/enricog/core/coroutines/testing/extensions/FlowTestExtensions.kt
+++ b/core/coroutines/testing/src/main/java/com/enricog/core/coroutines/testing/extensions/FlowTestExtensions.kt
@@ -65,7 +65,3 @@ private class FlowTempoImpl<T>(
         collectJob.cancelAndJoin()
     }
 }
-
-
-
-

--- a/core/coroutines/testing/src/main/java/com/enricog/core/coroutines/testing/extensions/FlowTestExtensions.kt
+++ b/core/coroutines/testing/src/main/java/com/enricog/core/coroutines/testing/extensions/FlowTestExtensions.kt
@@ -1,0 +1,71 @@
+package com.enricog.core.coroutines.testing.extensions
+
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Test a flow eagerly: this function allow to test a flow differently from Turbine.
+ * In Turbine the flow is collected with a channel, in which every item is being waited
+ * before doing the assertion. This does not allow to have more time base specific tests since
+ * it is making [advanceTimeBy] useless because the test is suspended until the child coroutines is executed.
+ * With this method instead the assertion is executed eagerly without waiting for the child coroutine
+ * to be executed, so it is required to use [advanceTimeBy] or [advanceUntilIdle] before doing the assertion
+ * to make sure the the child coroutine is executed.
+ * This has been made for very specific use cases to test the flow values in a specific point in time.
+ * The test function from Turbine should be used in all other cases.
+ */
+suspend fun <T> Flow<T>.testEager(
+    validate: suspend FlowTempo<T>.() -> Unit
+) {
+    coroutineScope {
+        val items = mutableListOf<T>()
+        val collectJob = launch {
+            this@testEager.toList(items)
+        }
+        FlowTempoImpl(items, collectJob).apply {
+            validate()
+            cancel()
+        }
+    }
+}
+
+interface FlowTempo<T> {
+
+    fun item(consume: Boolean = true): T
+
+    fun skip(num: Int)
+
+    suspend fun cancel()
+}
+
+private class FlowTempoImpl<T>(
+    private val items: MutableList<T>,
+    private val collectJob: Job
+) : FlowTempo<T> {
+
+    private var count = AtomicInteger(0)
+
+    override fun item(consume: Boolean): T {
+        return items.getOrNull(count.getAndIncrement())
+            ?: throw AssertionError("Expected item but not found at position ${count.get()}")
+    }
+
+    override fun skip(num: Int) {
+        count.updateAndGet { it + num }
+    }
+
+    override suspend fun cancel() {
+        collectJob.cancelAndJoin()
+    }
+}
+
+
+
+

--- a/core/coroutines/testing/src/main/java/com/enricog/core/coroutines/testing/extensions/FlowTestExtensions.kt
+++ b/core/coroutines/testing/src/main/java/com/enricog/core/coroutines/testing/extensions/FlowTestExtensions.kt
@@ -38,7 +38,7 @@ suspend fun <T> Flow<T>.testEager(
 
 interface FlowTempo<T> {
 
-    fun item(consume: Boolean = true): T
+    fun item(): T
 
     fun skip(num: Int)
 
@@ -52,7 +52,7 @@ private class FlowTempoImpl<T>(
 
     private var count = AtomicInteger(0)
 
-    override fun item(consume: Boolean): T {
+    override fun item(): T {
         return items.getOrNull(count.getAndIncrement())
             ?: throw AssertionError("Expected item but not found at position ${count.get()}")
     }

--- a/features/timer/src/test/java/com/enricog/features/timer/TimerViewModelTest.kt
+++ b/features/timer/src/test/java/com/enricog/features/timer/TimerViewModelTest.kt
@@ -3,6 +3,7 @@ package com.enricog.features.timer
 import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
 import com.enricog.core.coroutines.testing.CoroutineRule
+import com.enricog.core.coroutines.testing.extensions.testEager
 import com.enricog.data.local.testing.FakeStore
 import com.enricog.data.routines.api.entities.Routine
 import com.enricog.data.routines.api.entities.Segment
@@ -81,10 +82,11 @@ class TimerViewModelTest {
         )
         val sut = buildSut()
 
-        sut.viewState.test {
-            assertEquals(expectedOnSetup, awaitItem())
+        sut.viewState.testEager {
+            advanceTimeBy(100)
+            assertEquals(expectedOnSetup, item())
             advanceTimeBy(1000)
-            assertEquals(expectedOnStart, awaitItem())
+            assertEquals(expectedOnStart, item())
         }
         windowScreenManager.keepScreenOn.test { assertTrue(awaitItem()) }
     }
@@ -103,16 +105,14 @@ class TimerViewModelTest {
         )
         val sut = buildSut()
 
-        sut.viewState.test {
-            awaitItem()
-            advanceTimeBy(1000)
-            awaitItem()
-            advanceTimeBy(1000)
-            awaitItem()
+        sut.viewState.testEager {
+            advanceTimeBy(3000)
+            skip(3)
 
             sut.onStartStopButtonClick()
 
-            assertEquals(expected, awaitItem())
+            advanceTimeBy(100)
+            assertEquals(expected, item())
         }
         windowScreenManager.keepScreenOn.test { assertFalse(awaitItem()) }
     }
@@ -131,16 +131,14 @@ class TimerViewModelTest {
         )
         val sut = buildSut()
 
-        sut.viewState.test {
-            awaitItem()
-            advanceTimeBy(1000)
-            awaitItem()
-            advanceTimeBy(1000)
-            awaitItem()
+        sut.viewState.testEager {
+            advanceTimeBy(3000)
+            skip(3)
 
             sut.onResetButtonClick()
 
-            assertEquals(expected, awaitItem())
+            advanceTimeBy(100)
+            assertEquals(expected, item())
         }
     }
 
@@ -168,22 +166,16 @@ class TimerViewModelTest {
         )
         val sut = buildSut()
 
-        sut.viewState.test {
-            awaitItem()
+        sut.viewState.testEager {
+            advanceTimeBy(5000)
+            skip(5)
             advanceTimeBy(1000)
-            awaitItem()
-            advanceTimeBy(1000)
-            awaitItem()
-            advanceTimeBy(1000)
-            awaitItem()
-            advanceTimeBy(1000)
-            awaitItem()
-            advanceTimeBy(1000)
-            assertEquals(expectedStartFirstSegment, awaitItem())
+            assertEquals(expectedStartFirstSegment, item())
 
             sut.onResetButtonClick()
 
-            assertEquals(expectedStart, awaitItem())
+            advanceTimeBy(100)
+            assertEquals(expectedStart, item())
         }
     }
 


### PR DESCRIPTION
Add flow extension function `testEager` to be able to test a flow based on the time.

**Note**: This is for testing a very specific use case where it is required to have more control over the time in which an item of the flow is being emitted. Turbine should be used in all the other cases.

Currently, the `test` function from Turbine to test a flow is waiting for every item from the flow before doing the assertion, this is making the test suspend and execute the child coroutines until an item is collected.

This is making the `advanceTimeBy` function from the coroutine testing library kinda useless since, in Turbine, we wait for every item before doing the assertion so it is not possible to test the item of a flow at a specific point in time.
For example, if we have a test  subject like the following:
```
val state = MutableStateFlow(0)
fun foo() {
        scope.launch {
            state.value = 1
            delay(1000)
            state.value = 2
        }
    }
```
And we have the following test using Turbine:
```
@Test
fun testState() = runTest {
        val sut = TestSubject()
        
        sut.foo()

        sut.state.test {
              assertEquals(1, awaitItem())  // the main test coroutine suspends here, so the child is executed
              assertEquals(2, awaitItem())
        }
}
```
This test will always succeed regardless of the time that elapses between state updates. 

With `runEager` function the same test will look as follow:
```
@Test
fun testState() = runTest {
        val sut = TestSubject()
        
        sut.foo()

        sut.state.testEager {
              assertEquals(1, item()) // the main test coroutine does not suspend here, so we get the collected item until this point

              advanceTimeBy(1000) // this will make the child coroutine execution to complete so the state is updated

              assertEquals(2, item())
        }
}
```
In this case, the test will fail if after 1-second item `2` is not emitted. If  `advanceTimeBy`  is missing or has a wrong time the test will fail since the assertion is being done before the item in the flow is being emitted.


