### PR TITLE
Review theme and fix component position in landscape

### DIFF
--- a/app/src/main/java/com/enricog/tempo/MainActivity.kt
+++ b/app/src/main/java/com/enricog/tempo/MainActivity.kt
@@ -6,6 +6,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.core.view.WindowCompat
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.NavController.OnDestinationChangedListener
 import androidx.navigation.compose.NavHost
@@ -40,6 +41,7 @@ internal class MainActivity : ComponentActivity() {
     lateinit var dispatchers: CoroutineDispatchers
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        WindowCompat.setDecorFitsSystemWindows(window, false)
         super.onCreate(savedInstanceState)
         setContent {
             TempoTheme {

--- a/base/extensions/src/main/java/com/enricog/base/extensions/ClassExtensions.kt
+++ b/base/extensions/src/main/java/com/enricog/base/extensions/ClassExtensions.kt
@@ -1,5 +1,0 @@
-package com.enricog.base.extensions
-
-@Deprecated(message = "Not necessary anymore after kotlin 1.7", replaceWith = ReplaceWith(""))
-val <T> T.exhaustive: T
-    get() = this

--- a/features/routines/src/main/java/com/enricog/features/routines/detail/routine/RoutineScreen.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/detail/routine/RoutineScreen.kt
@@ -1,15 +1,13 @@
 package com.enricog.features.routines.detail.routine
 
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.TextFieldValue
 import com.enricog.features.routines.detail.routine.models.RoutineViewState
 import com.enricog.features.routines.detail.routine.ui_components.RoutineErrorScene
 import com.enricog.features.routines.detail.routine.ui_components.RoutineFormScene
+import com.enricog.ui.components.layout.scafold.TempoScreenScaffold
 import com.enricog.ui.components.snackbar.TempoSnackbarEvent
 import com.enricog.ui.components.textField.TimeText
 import com.enricog.ui.components.toolbar.TempoToolbar
@@ -17,7 +15,7 @@ import com.enricog.ui.components.toolbar.TempoToolbar
 @Composable
 internal fun RoutineScreen(viewModel: RoutineViewModel) {
     val viewState by viewModel.viewState.collectAsState(RoutineViewState.Idle)
-    Column(modifier = Modifier.fillMaxSize()) {
+    TempoScreenScaffold {
         TempoToolbar(onBack = viewModel::onRoutineBack)
         viewState.Compose(
             onRoutineNameChange = viewModel::onRoutineNameTextChange,

--- a/features/routines/src/main/java/com/enricog/features/routines/detail/segment/SegmentScreen.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/detail/segment/SegmentScreen.kt
@@ -1,16 +1,14 @@
 package com.enricog.features.routines.detail.segment
 
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.TextFieldValue
 import com.enricog.data.routines.api.entities.TimeType
 import com.enricog.features.routines.detail.segment.models.SegmentViewState
 import com.enricog.features.routines.detail.segment.ui_components.SegmentErrorScene
 import com.enricog.features.routines.detail.segment.ui_components.SegmentFormScene
+import com.enricog.ui.components.layout.scafold.TempoScreenScaffold
 import com.enricog.ui.components.snackbar.TempoSnackbarEvent
 import com.enricog.ui.components.textField.TimeText
 import com.enricog.ui.components.toolbar.TempoToolbar
@@ -18,7 +16,7 @@ import com.enricog.ui.components.toolbar.TempoToolbar
 @Composable
 internal fun SegmentScreen(viewModel: SegmentViewModel) {
     val viewState by viewModel.viewState.collectAsState(SegmentViewState.Idle)
-    Column(modifier = Modifier.fillMaxSize()) {
+    TempoScreenScaffold {
         TempoToolbar(onBack = viewModel::onSegmentBack)
 
         viewState.Compose(

--- a/features/routines/src/main/java/com/enricog/features/routines/detail/segment/ui_components/SegmentFormScene.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/detail/segment/ui_components/SegmentFormScene.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.unit.dp
 import com.enricog.core.compose.api.extensions.stringResourceOrNull
 import com.enricog.core.compose.api.modifiers.swipeable.rememberSwipeableState
 import com.enricog.data.routines.api.entities.TimeType
@@ -95,6 +96,7 @@ internal fun SegmentFormScene(
                     modifier = Modifier
                         .fillMaxSize()
                         .verticalScroll(rememberScrollState(0))
+                        .padding(bottom = 85.dp)
                 ) {
                     TempoTextField(
                         value = segment.name,

--- a/features/routines/src/main/java/com/enricog/features/routines/detail/segment/ui_components/SegmentPager.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/detail/segment/ui_components/SegmentPager.kt
@@ -1,5 +1,6 @@
 package com.enricog.features.routines.detail.segment.ui_components
 
+import android.content.res.Configuration.ORIENTATION_PORTRAIT
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -8,6 +9,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.unit.dp
 import com.enricog.core.compose.api.extensions.stringResourceOrNull
 import com.enricog.core.compose.api.extensions.toPx
@@ -33,9 +35,11 @@ internal fun SegmentPager(
     modifier: Modifier = Modifier
 ) = BoxWithConstraints(modifier = modifier) {
 
-    val errorMessage = stringResourceOrNull(errors[SegmentField.Time]?.stringResId) ?: ""
+    val configuration = LocalConfiguration.current
 
-    val circleRadius = maxWidth / 3
+    val circleShrinkFactor = if (configuration.orientation == ORIENTATION_PORTRAIT) 3 else 6
+
+    val circleRadius = maxWidth / circleShrinkFactor
     val center = maxWidth / 2
     val circleSpace = 120.dp
 
@@ -69,7 +73,7 @@ internal fun SegmentPager(
                 .height(35.dp)
                 .padding(vertical = TempoTheme.dimensions.spaceS)
                 .align(alignment = Alignment.CenterHorizontally),
-            text = errorMessage,
+            text = stringResourceOrNull(errors[SegmentField.Time]?.stringResId) ?: "",
             style = TempoTheme.typography.caption.copy(
                 color = TempoTheme.colors.error
             ),

--- a/features/routines/src/main/java/com/enricog/features/routines/detail/start_time/StartTimeInfoScene.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/detail/start_time/StartTimeInfoScene.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.modifier.modifierLocalOf
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import com.enricog.features.routines.R

--- a/features/routines/src/main/java/com/enricog/features/routines/detail/start_time/StartTimeInfoScene.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/detail/start_time/StartTimeInfoScene.kt
@@ -1,7 +1,11 @@
 package com.enricog.features.routines.detail.start_time
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
@@ -24,6 +28,8 @@ internal fun StartTimeInfoScene() {
     Column(
         modifier = Modifier
             .verticalScroll(scrollState)
+            .windowInsetsPadding(WindowInsets.navigationBars)
+            .windowInsetsPadding(WindowInsets.statusBars)
             .padding(TempoTheme.dimensions.spaceM)
             .testTag(StartTimeInfoSceneTestTag)
     ) {

--- a/features/routines/src/main/java/com/enricog/features/routines/detail/summary/RoutineSummaryScreen.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/detail/summary/RoutineSummaryScreen.kt
@@ -1,22 +1,20 @@
 package com.enricog.features.routines.detail.summary
 
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Modifier
 import com.enricog.data.routines.api.entities.Segment
 import com.enricog.features.routines.detail.summary.models.RoutineSummaryViewState
 import com.enricog.features.routines.detail.summary.ui_components.RoutineSummaryErrorScene
 import com.enricog.features.routines.detail.summary.ui_components.RoutineSummaryScene
+import com.enricog.ui.components.layout.scafold.TempoScreenScaffold
 import com.enricog.ui.components.snackbar.TempoSnackbarEvent
 import com.enricog.ui.components.toolbar.TempoToolbar
 
 @Composable
 internal fun RoutineSummaryScreen(viewModel: RoutineSummaryViewModel) {
     val viewState by viewModel.viewState.collectAsState(RoutineSummaryViewState.Idle)
-    Column(modifier = Modifier.fillMaxSize()) {
+    TempoScreenScaffold {
         TempoToolbar(onBack = viewModel::onBack)
         viewState.Compose(
             onSegmentAdd = viewModel::onSegmentAdd,

--- a/features/routines/src/main/java/com/enricog/features/routines/detail/summary/ui_components/SummaryList.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/detail/summary/ui_components/SummaryList.kt
@@ -15,7 +15,6 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
-import com.enricog.base.extensions.exhaustive
 import com.enricog.core.compose.api.extensions.toPx
 import com.enricog.core.compose.api.modifiers.draggable.ListDraggableState
 import com.enricog.data.routines.api.entities.Segment
@@ -100,7 +99,7 @@ internal fun SummaryList(
                     }
                 }
                 RoutineSummaryItem.Space -> Spacer(modifier = Modifier.height(85.dp))
-            }.exhaustive
+            }
         }
     }
 }

--- a/features/routines/src/main/java/com/enricog/features/routines/list/RoutinesScreen.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/list/RoutinesScreen.kt
@@ -1,11 +1,8 @@
 package com.enricog.features.routines.list
 
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import com.enricog.data.routines.api.entities.Routine
 import com.enricog.features.routines.R
@@ -13,6 +10,7 @@ import com.enricog.features.routines.list.models.RoutinesViewState
 import com.enricog.features.routines.list.ui_components.RoutinesEmptyScene
 import com.enricog.features.routines.list.ui_components.RoutinesErrorScene
 import com.enricog.features.routines.list.ui_components.RoutinesScene
+import com.enricog.ui.components.layout.scafold.TempoScreenScaffold
 import com.enricog.ui.components.snackbar.TempoSnackbarEvent
 import com.enricog.ui.components.toolbar.TempoToolbar
 
@@ -20,7 +18,7 @@ import com.enricog.ui.components.toolbar.TempoToolbar
 internal fun RoutinesScreen(viewModel: RoutinesViewModel) {
     val viewState by viewModel.viewState.collectAsState(RoutinesViewState.Idle)
 
-    Column(modifier = Modifier.fillMaxSize()) {
+    TempoScreenScaffold {
         TempoToolbar(title = stringResource(R.string.title_routines))
         viewState.Compose(
             onCreateRoutine = viewModel::onCreateRoutine,

--- a/features/timer/src/main/java/com/enricog/features/timer/TimerScreen.kt
+++ b/features/timer/src/main/java/com/enricog/features/timer/TimerScreen.kt
@@ -9,7 +9,10 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.scaleIn
 import androidx.compose.animation.with
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -35,6 +38,7 @@ internal fun TimerScreen(viewModel: TimerViewModel) {
         TimerToolbar(
             modifier = Modifier
                 .align(Alignment.TopStart)
+                .windowInsetsPadding(WindowInsets.statusBars)
                 .zIndex(1f),
             state = viewState,
             onCloseClick = { showCloseDialog = true },

--- a/features/timer/src/main/java/com/enricog/features/timer/ui_components/TimerCountingScene.kt
+++ b/features/timer/src/main/java/com/enricog/features/timer/ui_components/TimerCountingScene.kt
@@ -1,7 +1,6 @@
 package com.enricog.features.timer.ui_components
 
 import android.content.res.Configuration.ORIENTATION_PORTRAIT
-import android.media.MediaPlayer
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.Column
@@ -16,7 +15,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -96,12 +94,13 @@ internal fun TimerCountingScene(
                     .constrainAs(clock) {
                         if (orientation == ORIENTATION_PORTRAIT) {
                             top.linkTo(title.bottom)
+                            bottom.linkTo(actionBar.top)
                         } else {
                             top.linkTo(parent.top)
+                            bottom.linkTo(parent.bottom)
                         }
                         start.linkTo(parent.start)
                         end.linkTo(parent.end)
-                        bottom.linkTo(actionBar.top)
                     }
             )
 
@@ -111,8 +110,13 @@ internal fun TimerCountingScene(
                 onRestartSegmentButtonClick = onRestartSegment,
                 modifier = Modifier
                     .constrainAs(actionBar) {
-                        top.linkTo(clock.bottom)
-                        start.linkTo(parent.start)
+                        if (orientation == ORIENTATION_PORTRAIT) {
+                            top.linkTo(clock.bottom)
+                            start.linkTo(parent.start)
+                        } else {
+                            top.linkTo(parent.top)
+                            start.linkTo(clock.end)
+                        }
                         end.linkTo(parent.end)
                         bottom.linkTo(parent.bottom)
                     }

--- a/ui/components/src/main/java/com/enricog/ui/components/layout/scafold/TempoScreenScaffold.kt
+++ b/ui/components/src/main/java/com/enricog/ui/components/layout/scafold/TempoScreenScaffold.kt
@@ -1,0 +1,25 @@
+package com.enricog.ui.components.layout.scafold
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+@Composable
+fun TempoScreenScaffold(
+    modifier: Modifier = Modifier,
+    content: @Composable ColumnScope.() -> Unit
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .windowInsetsPadding(WindowInsets.navigationBars)
+            .windowInsetsPadding(WindowInsets.statusBars),
+        content = content
+    )
+}


### PR DESCRIPTION
Review the component's position in `TimerCountingScene` and `SegmentFormScene` to fit better when the phone orientation is in landscape.

Make activity fill the full windows: updated the insets in the "Screens" components in orderd to not overlap with the status and navigation bar