### PR TITLE
Fix: TimeText parsing from string

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -52,7 +52,7 @@ android {
             minifyEnabled true
             proguardFiles 'proguard-rules.pro'
             firebaseCrashlytics {
-                mappingFileUploadEnabled false
+                mappingFileUploadEnabled true
             }
         }
     }

--- a/ui/components/src/main/java/com/enricog/ui/components/textField/TimeText.kt
+++ b/ui/components/src/main/java/com/enricog/ui/components/textField/TimeText.kt
@@ -79,7 +79,12 @@ value class TimeText private constructor(private val value: String) : Comparable
         }
 
         fun from(value: String): TimeText {
-            return TimeText(value.replace(oldValue = TIME_SEPARATOR, newValue = ""))
+            val sanitizedValue = value
+                .replace(oldValue = TIME_SEPARATOR, newValue = "")
+                .replace(oldValue = "\n", newValue = "")
+                .replace(oldValue = "\r", newValue = "")
+                .trimStart('0')
+            return TimeText(sanitizedValue)
         }
     }
 }

--- a/ui/components/src/test/java/com/enricog/ui/components/textField/TimeTextTest.kt
+++ b/ui/components/src/test/java/com/enricog/ui/components/textField/TimeTextTest.kt
@@ -22,6 +22,13 @@ class TimeTextTest {
     private class ValidArgumentProvider : ArgumentsProvider {
         override fun provideArguments(context: ExtensionContext?): Stream<out Arguments> {
             return Stream.of(
+                """0
+""" to 0,
+                "0\n" to 0,
+                "0\r" to 0,
+                "0\r\n" to 0,
+                "0\n0" to 0,
+                "0000" to 0,
                 "9" to 9,
                 "89" to 89,
                 "891" to 571,
@@ -31,6 +38,7 @@ class TimeTextTest {
                 "000052" to 52,
                 "200052" to 72052,
                 "201052" to 72652,
+                "2010\n52" to 72652,
                 "6000" to 3600,
                 "60000" to 21600,
                 // Over max value


### PR DESCRIPTION
### Trailing 0 (zeros)
Trailing zeros are removed from the string value that is parsed. They are not significant and also improve the UX when using the `TempoTimeField` since when showing `00:00` adding other 0 is not going to add them in the text field value

### Remove newline characters
New line characters are removed from the string to try to avoid `NumberFormatException` in this cases
