### PR TITLE
Fix: Crash when dragging items

### DIFF
--- a/features/routines/src/main/java/com/enricog/features/routines/detail/summary/ui_components/RoutineSummaryScene.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/detail/summary/ui_components/RoutineSummaryScene.kt
@@ -47,7 +47,10 @@ internal fun RoutineSummaryScene(
     onSnackbarEvent: (TempoSnackbarEvent) -> Unit
 ) {
 
-    val listDraggableState = rememberListDraggableState(key = summaryItems)
+    val listDraggableState = rememberListDraggableState(
+        key = summaryItems,
+        isItemDraggable = { index -> summaryItems[index] is SegmentItem }
+    )
     val snackbarHostState = rememberSnackbarHostState()
 
     if (message != null) {


### PR DESCRIPTION
Fix a crash when, in the RoutineSummary, trying to drag an item that is not a segment. The issue has been fixed by checking the type of item that is being dragged.