### PR TITLE
Feature: Routines can be ordered

### DIFF
--- a/.idea/androidTestResultsUserPreferences.xml
+++ b/.idea/androidTestResultsUserPreferences.xml
@@ -29,6 +29,19 @@
             </AndroidTestResultsTableState>
           </value>
         </entry>
+        <entry key="-1320464652">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Pixel_4_API_R" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
         <entry key="-1019906868">
           <value>
             <AndroidTestResultsTableState>
@@ -149,6 +162,19 @@
                   <entry key="19291FDF6002X0" value="120" />
                   <entry key="Duration" value="90" />
                   <entry key="Google&#10; Pixel 6" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
+        <entry key="1571338564">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Pixel_4_API_R" value="120" />
                   <entry key="Tests" value="360" />
                 </map>
               </option>

--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="deploymentTargetDropDown">
+    <targetSelectedWithDropDown>
+      <Target>
+        <type value="QUICK_BOOT_TARGET" />
+        <deviceKey>
+          <Key>
+            <type value="VIRTUAL_DEVICE_PATH" />
+            <value value="C:\Users\fd\.android\avd\Pixel_4_API_R.avd" />
+          </Key>
+        </deviceKey>
+      </Target>
+    </targetSelectedWithDropDown>
+    <timeTargetWasSelectedWithDropDown value="2022-12-25T09:54:44.511303300Z" />
+  </component>
+</project>

--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -12,6 +12,6 @@
         </deviceKey>
       </Target>
     </targetSelectedWithDropDown>
-    <timeTargetWasSelectedWithDropDown value="2022-12-25T09:54:44.511303300Z" />
+    <timeTargetWasSelectedWithDropDown value="2022-12-26T10:59:21.683275300Z" />
   </component>
 </project>

--- a/buildSrc/src/main/java/com/enricog/tempo/buildsrc/dependencies.kt
+++ b/buildSrc/src/main/java/com/enricog/tempo/buildsrc/dependencies.kt
@@ -109,6 +109,7 @@ object Libs {
         const val runtime = "androidx.room:room-runtime:$version"
         const val compiler = "androidx.room:room-compiler:$version"
         const val ktx = "androidx.room:room-ktx:$version"
+        const val testing = "androidx.room:room-testing:$version"
     }
 
     const val Timber = "com.jakewharton.timber:timber:5.0.1"

--- a/core/compose/api/src/main/java/com/enricog/core/compose/api/classes/ImmutableList.kt
+++ b/core/compose/api/src/main/java/com/enricog/core/compose/api/classes/ImmutableList.kt
@@ -12,6 +12,10 @@ class ImmutableList<T : Any> internal constructor(private val list: List<T>) : L
     override fun hashCode(): Int {
         return list.hashCode()
     }
+
+    override fun toString(): String {
+        return list.toString()
+    }
 }
 
 fun <T : Any> immutableListOf(vararg elements: T): ImmutableList<T> = ImmutableList(

--- a/core/compose/api/src/main/java/com/enricog/core/compose/api/classes/ImmutableMap.kt
+++ b/core/compose/api/src/main/java/com/enricog/core/compose/api/classes/ImmutableMap.kt
@@ -13,6 +13,10 @@ class ImmutableMap<K : Any, V : Any> internal constructor(private val map: Map<K
     override fun hashCode(): Int {
         return map.hashCode()
     }
+
+    override fun toString(): String {
+        return map.toString()
+    }
 }
 
 fun <K : Any, V : Any> immutableMapOf(vararg pairs: Pair<K, V>): ImmutableMap<K, V> = ImmutableMap(

--- a/core/compose/api/src/main/java/com/enricog/core/compose/api/modifiers/draggable/ListDraggableModifier.kt
+++ b/core/compose/api/src/main/java/com/enricog/core/compose/api/modifiers/draggable/ListDraggableModifier.kt
@@ -137,6 +137,7 @@ class ListDraggableState(
                                 else -> startOffset > itemInfo.offset && startOffset < itemInfo.offsetEnd
                             }
                         }
+                        ?.takeIf { itemInfo -> isItemDraggable(itemInfo.index) } // Only draggable items can be hovered
                         ?.let { itemInfo -> hoveredItemIndex = itemInfo.index }
                 }
 

--- a/core/compose/api/src/main/java/com/enricog/core/compose/api/modifiers/draggable/ListDraggableModifier.kt
+++ b/core/compose/api/src/main/java/com/enricog/core/compose/api/modifiers/draggable/ListDraggableModifier.kt
@@ -107,8 +107,7 @@ class ListDraggableState(
         draggedItem = listState.draggedItemInfo(dragAmount.y)
             ?.takeIf { item -> isItemDraggable(item.index) }
             ?.also { item ->
-                val index = item.index
-                hoveredItemIndex = index
+                hoveredItemIndex = item.index
                 draggedItemOffsetY += item.offset
             }
     }

--- a/data/local/database/build.gradle
+++ b/data/local/database/build.gradle
@@ -15,6 +15,8 @@ android {
     defaultConfig {
         minSdkVersion Versions.minSdk
 
+        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
+
         javaCompileOptions {
             annotationProcessorOptions {
                 arguments = [
@@ -35,6 +37,10 @@ android {
         unitTests {
             includeAndroidResources = true
         }
+    }
+
+    sourceSets {
+        androidTest.assets.srcDirs += files("$projectDir/schemas".toString())
     }
 }
 
@@ -61,4 +67,11 @@ dependencies {
     testImplementation Libs.AndroidX.Test.archCore
     testImplementation Libs.Test.junit
     testImplementation Libs.Robolectric
+
+    androidTestImplementation project(':data:routines:testing')
+    androidTestImplementation Libs.Room.testing
+    androidTestImplementation Libs.AndroidX.Test.junitKtx
+    androidTestImplementation Libs.Test.junit
+    androidTestImplementation Libs.AndroidX.Test.core
+    androidTestImplementation Libs.AndroidX.Test.rules
 }

--- a/data/local/database/schemas/com.enricog.data.local.database.TempoDatabase/1.json
+++ b/data/local/database/schemas/com.enricog.data.local.database.TempoDatabase/1.json
@@ -2,11 +2,11 @@
   "formatVersion": 1,
   "database": {
     "version": 1,
-    "identityHash": "298529df1f045a78983c62158d7764e5",
+    "identityHash": "16677cb21c9fcb71cb991c73755b44bd",
     "entities": [
       {
         "tableName": "Routines",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`routineId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `startTimeOffsetInSeconds` INTEGER NOT NULL, `createdAt` TEXT NOT NULL, `updatedAt` TEXT NOT NULL)",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`routineId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `startTimeOffsetInSeconds` INTEGER NOT NULL, `createdAt` TEXT NOT NULL, `updatedAt` TEXT NOT NULL, `rank` TEXT NOT NULL)",
         "fields": [
           {
             "fieldPath": "id",
@@ -35,6 +35,12 @@
           {
             "fieldPath": "updatedAt",
             "columnName": "updatedAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rank",
+            "columnName": "rank",
             "affinity": "TEXT",
             "notNull": true
           }
@@ -124,7 +130,7 @@
     "views": [],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '298529df1f045a78983c62158d7764e5')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '16677cb21c9fcb71cb991c73755b44bd')"
     ]
   }
 }

--- a/data/local/database/schemas/com.enricog.data.local.database.TempoDatabase/2.json
+++ b/data/local/database/schemas/com.enricog.data.local.database.TempoDatabase/2.json
@@ -1,12 +1,12 @@
 {
   "formatVersion": 1,
   "database": {
-    "version": 1,
-    "identityHash": "298529df1f045a78983c62158d7764e5",
+    "version": 2,
+    "identityHash": "16677cb21c9fcb71cb991c73755b44bd",
     "entities": [
       {
         "tableName": "Routines",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`routineId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `startTimeOffsetInSeconds` INTEGER NOT NULL, `createdAt` TEXT NOT NULL, `updatedAt` TEXT NOT NULL)",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`routineId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `startTimeOffsetInSeconds` INTEGER NOT NULL, `createdAt` TEXT NOT NULL, `updatedAt` TEXT NOT NULL, `rank` TEXT NOT NULL)",
         "fields": [
           {
             "fieldPath": "id",
@@ -35,6 +35,12 @@
           {
             "fieldPath": "updatedAt",
             "columnName": "updatedAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rank",
+            "columnName": "rank",
             "affinity": "TEXT",
             "notNull": true
           }
@@ -124,7 +130,7 @@
     "views": [],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '298529df1f045a78983c62158d7764e5')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '16677cb21c9fcb71cb991c73755b44bd')"
     ]
   }
 }

--- a/data/local/database/src/androidTest/java/com/enricog/data/local/database/migrations/MigrationFrom1To2Test.kt
+++ b/data/local/database/src/androidTest/java/com/enricog/data/local/database/migrations/MigrationFrom1To2Test.kt
@@ -1,0 +1,85 @@
+package com.enricog.data.local.database.migrations
+
+import androidx.room.testing.MigrationTestHelper
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.enricog.data.local.database.TempoDatabase
+import junit.framework.TestCase.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class MigrationFrom1To2Test {
+
+    @get:Rule
+    val helper: MigrationTestHelper = MigrationTestHelper(
+        InstrumentationRegistry.getInstrumentation(),
+        TempoDatabase::class.java
+    )
+
+    @Test
+    fun shouldApplyRankWhenDatabaseContainsRoutines() {
+        helper.createDatabase(TEST_DB, 1).apply {
+            execSQL(
+                """
+                INSERT INTO Routines (name, startTimeOffsetInSeconds, createdAt, updatedAt)
+                VALUES ('Routine 1', 0, '2022-12-25T17:49:30+01:00', '2022-12-25T17:49:30+01:00')
+            """.trimIndent()
+            )
+            execSQL(
+                """
+                INSERT INTO Routines (name, startTimeOffsetInSeconds, createdAt, updatedAt)
+                VALUES ('Routine 2', 0, '2022-12-25T17:50:30+01:00', '2022-12-25T17:50:30+01:00')
+            """.trimIndent()
+            )
+            execSQL(
+                """
+                INSERT INTO Routines (name, startTimeOffsetInSeconds, createdAt, updatedAt)
+                VALUES ('Routine 3', 0, '2022-12-25T17:51:30+01:00', '2022-12-25T17:51:30+01:00')
+            """.trimIndent()
+            )
+            execSQL(
+                """
+                INSERT INTO Routines (name, startTimeOffsetInSeconds, createdAt, updatedAt)
+                VALUES ('Routine 4', 0, '2022-12-25T17:52:30+01:00', '2022-12-25T17:52:30+01:00')
+            """.trimIndent()
+            )
+
+            close()
+        }
+
+        val db = helper.runMigrationsAndValidate(TEST_DB, 2, true, MigrationFrom1To2)
+
+        val cursor = db.query("SELECT * FROM Routines ORDER BY createdAt DESC")
+
+        with(cursor) {
+            moveToNext()
+            assertEquals("Routine 4", getString(getColumnIndex("name")))
+            assertEquals("mzzzzz", getString(getColumnIndex("rank")))
+
+            moveToNext()
+            assertEquals("Routine 3", getString(getColumnIndex("name")))
+            assertEquals("tmzzzz", getString(getColumnIndex("rank")))
+
+            moveToNext()
+            assertEquals("Routine 2", getString(getColumnIndex("name")))
+            assertEquals("wtmzzz", getString(getColumnIndex("rank")))
+
+            moveToNext()
+            assertEquals("Routine 1", getString(getColumnIndex("name")))
+            assertEquals("yjtmzz", getString(getColumnIndex("rank")))
+        }
+    }
+
+    @Test
+    fun shouldApplyOnlyMigrationWhenDatabaseHasNoRoutines() {
+        helper.createDatabase(TEST_DB, 1).apply { close() }
+
+        helper.runMigrationsAndValidate(TEST_DB, 2, true, MigrationFrom1To2)
+    }
+
+    private companion object {
+        private const val TEST_DB = "migration-test"
+    }
+}

--- a/data/local/database/src/main/java/com/enricog/data/local/database/TempoDatabase.kt
+++ b/data/local/database/src/main/java/com/enricog/data/local/database/TempoDatabase.kt
@@ -7,6 +7,7 @@ import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
 import com.enricog.data.local.database.converter.OffsetDateTimeConverter
 import com.enricog.data.local.database.converter.TimeTypeConverter
+import com.enricog.data.local.database.migrations.MigrationFrom1To2
 import com.enricog.data.local.database.routines.dao.RoutineDao
 import com.enricog.data.local.database.routines.dao.SegmentDao
 import com.enricog.data.local.database.routines.model.InternalRoutine
@@ -16,7 +17,8 @@ import com.enricog.data.local.database.routines.model.InternalSegment
     entities = [
         InternalRoutine::class,
         InternalSegment::class,
-    ], version = 1
+    ],
+    version = 2
 )
 @TypeConverters(
     TimeTypeConverter::class,
@@ -38,11 +40,10 @@ internal abstract class TempoDatabase : RoomDatabase() {
         }
 
         private fun buildDatabase(context: Context): TempoDatabase {
-            return Room.databaseBuilder(
-                context.applicationContext,
-                TempoDatabase::class.java,
-                "Tempo.db"
-            ).build()
+            return Room
+                .databaseBuilder(context.applicationContext, TempoDatabase::class.java, "Tempo.db")
+                .addMigrations(MigrationFrom1To2)
+                .build()
         }
     }
 }

--- a/data/local/database/src/main/java/com/enricog/data/local/database/migrations/MigrationFrom1To2.kt
+++ b/data/local/database/src/main/java/com/enricog/data/local/database/migrations/MigrationFrom1To2.kt
@@ -1,0 +1,32 @@
+package com.enricog.data.local.database.migrations
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+import com.enricog.entities.Rank
+
+internal object MigrationFrom1To2 : Migration(1, 2) {
+
+    override fun migrate(database: SupportSQLiteDatabase) {
+        database.execSQL("ALTER TABLE Routines ADD COLUMN rank TEXT NOT NULL DEFAULT('')")
+
+        val numberRoutine = database.compileStatement("SELECT COUNT(*) FROM Routines")
+            .simpleQueryForLong()
+
+        if(numberRoutine == 0L) return
+
+        var rankTop: Rank? = null
+        for (num in 0L until numberRoutine) {
+
+            val rank = if (rankTop == null) Rank.calculateFirst() else
+                Rank.calculateBottom(rankTop)
+            rankTop = rank
+
+            database.execSQL(
+                """
+                    UPDATE Routines SET rank='$rank'
+                    WHERE routineId = (SELECT routineId FROM Routines ORDER BY createdAt DESC LIMIT 1 OFFSET $num)
+                """.trimIndent()
+            )
+        }
+    }
+}

--- a/data/local/database/src/main/java/com/enricog/data/local/database/routines/RoutineDataSourceImpl.kt
+++ b/data/local/database/src/main/java/com/enricog/data/local/database/routines/RoutineDataSourceImpl.kt
@@ -32,6 +32,12 @@ internal class RoutineDataSourceImpl @Inject constructor(
             .map(InternalRoutineWithSegments::toEntity)
     }
 
+    override suspend fun getAll(): List<Routine> {
+        return database.routineDao().getAll()
+            .map(InternalRoutineWithSegments::toEntity)
+            .sortedByRank()
+    }
+
     override suspend fun get(id: ID): Routine {
         return database.routineDao().get(id.toLong()).toEntity()
     }

--- a/data/local/database/src/main/java/com/enricog/data/local/database/routines/RoutineDataSourceImpl.kt
+++ b/data/local/database/src/main/java/com/enricog/data/local/database/routines/RoutineDataSourceImpl.kt
@@ -1,12 +1,13 @@
 package com.enricog.data.local.database.routines
 
 import android.annotation.SuppressLint
-import com.enricog.data.routines.api.RoutineDataSource
-import com.enricog.entities.ID
-import com.enricog.data.routines.api.entities.Routine
 import com.enricog.data.local.database.TempoDatabase
 import com.enricog.data.local.database.routines.model.InternalRoutineWithSegments
 import com.enricog.data.local.database.routines.model.toInternal
+import com.enricog.data.routines.api.RoutineDataSource
+import com.enricog.data.routines.api.entities.Routine
+import com.enricog.data.routines.api.entities.sortedByRank
+import com.enricog.entities.ID
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -23,6 +24,7 @@ internal class RoutineDataSourceImpl @Inject constructor(
     override fun observeAll(): Flow<List<Routine>> {
         return database.routineDao().observeAll()
             .map { list -> list.map(InternalRoutineWithSegments::toEntity) }
+            .map { list -> list.sortedByRank() }
     }
 
     override fun observe(id: ID): Flow<Routine> {

--- a/data/local/database/src/main/java/com/enricog/data/local/database/routines/model/InternalRoutine.kt
+++ b/data/local/database/src/main/java/com/enricog/data/local/database/routines/model/InternalRoutine.kt
@@ -6,6 +6,7 @@ import androidx.room.PrimaryKey
 import com.enricog.data.routines.api.entities.Routine
 import com.enricog.data.routines.api.entities.sortedByRank
 import com.enricog.entities.ID
+import com.enricog.entities.Rank
 import com.enricog.entities.seconds
 import java.time.OffsetDateTime
 
@@ -15,7 +16,8 @@ internal data class InternalRoutine(
     @ColumnInfo(name = "name") val name: String,
     @ColumnInfo(name = "startTimeOffsetInSeconds") val startTimeOffsetInSeconds: Long,
     @ColumnInfo(name = "createdAt") val createdAt: OffsetDateTime,
-    @ColumnInfo(name = "updatedAt") val updatedAt: OffsetDateTime
+    @ColumnInfo(name = "updatedAt") val updatedAt: OffsetDateTime,
+    @ColumnInfo(name = "rank") val rank: String
 ) {
     fun toEntity(segments: List<InternalSegment>): Routine {
         return Routine(
@@ -26,7 +28,8 @@ internal data class InternalRoutine(
             updatedAt = updatedAt,
             segments = segments
                 .map { it.toEntity() }
-                .sortedByRank()
+                .sortedByRank(),
+            rank = Rank.from(rank)
         )
     }
 }
@@ -37,6 +40,7 @@ internal fun Routine.toInternal(): InternalRoutine {
         name = name,
         startTimeOffsetInSeconds = startTimeOffset.value,
         createdAt = createdAt,
-        updatedAt = updatedAt
+        updatedAt = updatedAt,
+        rank = rank.toString()
     )
 }

--- a/data/local/database/src/test/java/com/enricog/data/local/database/routines/RoutineDataSourceImplTest.kt
+++ b/data/local/database/src/test/java/com/enricog/data/local/database/routines/RoutineDataSourceImplTest.kt
@@ -72,7 +72,8 @@ class RoutineDataSourceImplTest {
             name = "name",
             startTimeOffsetInSeconds = 10,
             createdAt = now,
-            updatedAt = now
+            updatedAt = now,
+            rank = "abcdef"
         )
         val routine = Routine(
             id = 1.asID,
@@ -88,7 +89,8 @@ class RoutineDataSourceImplTest {
                     type = TimeType.TIMER,
                     Rank.from(value = "aaaaaa")
                 )
-            )
+            ),
+            rank = Rank.from(value = "abcdef")
         )
         val expected = listOf(routine)
 
@@ -116,7 +118,8 @@ class RoutineDataSourceImplTest {
             name = "name",
             startTimeOffsetInSeconds = 10,
             createdAt = now,
-            updatedAt = now
+            updatedAt = now,
+            rank = "abcdef"
         )
         val expected = Routine(
             id = 1.asID,
@@ -132,13 +135,60 @@ class RoutineDataSourceImplTest {
                     type = TimeType.TIMER,
                     rank = Rank.from(value = "aaaaaa")
                 )
-            )
+            ),
+            rank = Rank.from(value = "abcdef")
         )
 
         database.routineDao().insert(internalRoutine)
         database.segmentDao().insert(internalSegment)
 
         val result = sut.observe(1.asID).first()
+
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `should return all routines`() = coroutineRule {
+        val now = OffsetDateTime.now()
+        val internalSegment = InternalSegment(
+            id = 1,
+            routineId = 1,
+            name = "name",
+            timeInSeconds = 40,
+            type = TimeType.TIMER,
+            rank = "aaaaaa"
+        )
+        val internalRoutine = InternalRoutine(
+            id = 1,
+            name = "name",
+            startTimeOffsetInSeconds = 10,
+            createdAt = now,
+            updatedAt = now,
+            rank = "abcdef"
+        )
+        val routine = Routine(
+            id = 1.asID,
+            name = "name",
+            startTimeOffset = 10.seconds,
+            createdAt = now,
+            updatedAt = now,
+            segments = listOf(
+                Segment(
+                    id = 1.asID,
+                    name = "name",
+                    time = 40.seconds,
+                    type = TimeType.TIMER,
+                    Rank.from(value = "aaaaaa")
+                )
+            ),
+            rank = Rank.from(value = "abcdef")
+        )
+        val expected = listOf(routine)
+
+        database.routineDao().insert(internalRoutine)
+        database.segmentDao().insert(internalSegment)
+
+        val result = sut.getAll()
 
         assertEquals(expected, result)
     }
@@ -159,7 +209,8 @@ class RoutineDataSourceImplTest {
             name = "name",
             startTimeOffsetInSeconds = 10,
             createdAt = now,
-            updatedAt = now
+            updatedAt = now,
+            rank = "abcdef"
         )
         val expected = Routine(
             id = 1.asID,
@@ -175,7 +226,8 @@ class RoutineDataSourceImplTest {
                     type = TimeType.TIMER,
                     rank = Rank.from(value = "aaaaaa")
                 )
-            )
+            ),
+            rank = Rank.from(value = "abcdef")
         )
 
         database.routineDao().insert(internalRoutine)
@@ -204,7 +256,8 @@ class RoutineDataSourceImplTest {
                     type = TimeType.TIMER,
                     rank = Rank.from(value = "aaaaaa")
                 )
-            )
+            ),
+            rank = Rank.from(value = "abcdef")
         )
         val expected = Routine(
             id = 1.asID,
@@ -220,7 +273,8 @@ class RoutineDataSourceImplTest {
                     type = TimeType.TIMER,
                     rank = Rank.from(value = "aaaaaa")
                 )
-            )
+            ),
+            rank = Rank.from(value = "abcdef")
         )
 
         val routineId = sut.create(routine)
@@ -248,7 +302,8 @@ class RoutineDataSourceImplTest {
             name = "name",
             startTimeOffsetInSeconds = 10,
             createdAt = max,
-            updatedAt = max
+            updatedAt = max,
+            rank = "abcdef"
         )
         val routine = Routine(
             id = 1.asID,
@@ -264,7 +319,8 @@ class RoutineDataSourceImplTest {
                     type = TimeType.TIMER,
                     rank = Rank.from(value = "aaaaaa")
                 )
-            )
+            ),
+            rank = Rank.from(value = "abcdef")
         )
 
         database.routineDao().insert(internalRoutine)
@@ -295,7 +351,8 @@ class RoutineDataSourceImplTest {
             name = "name",
             startTimeOffsetInSeconds = 10,
             createdAt = max,
-            updatedAt = max
+            updatedAt = max,
+            rank = "abcdef"
         )
         val routine = Routine(
             id = 1.asID,
@@ -311,7 +368,8 @@ class RoutineDataSourceImplTest {
                     type = TimeType.TIMER,
                     rank = Rank.from(value = "aaaaaa")
                 )
-            )
+            ),
+            rank = Rank.from(value = "abcdef")
         )
 
         database.routineDao().insert(internalRoutine)
@@ -342,7 +400,8 @@ class RoutineDataSourceImplTest {
             name = "name",
             startTimeOffsetInSeconds = 10,
             createdAt = max,
-            updatedAt = max
+            updatedAt = max,
+            rank = "abcdef"
         )
         val routine = Routine(
             id = 1.asID,
@@ -350,7 +409,8 @@ class RoutineDataSourceImplTest {
             startTimeOffset = 10.seconds,
             createdAt = max,
             updatedAt = now,
-            segments = emptyList()
+            segments = emptyList(),
+            rank = Rank.from(value = "abcdef")
         )
 
         database.routineDao().insert(internalRoutine)
@@ -373,7 +433,8 @@ class RoutineDataSourceImplTest {
             name = "name",
             startTimeOffsetInSeconds = 10,
             createdAt = max,
-            updatedAt = max
+            updatedAt = max,
+            rank = "abcdef"
         )
         val routine = Routine(
             id = 1.asID,
@@ -389,7 +450,8 @@ class RoutineDataSourceImplTest {
                     type = TimeType.TIMER,
                     rank = Rank.from(value = "aaaaaa")
                 )
-            )
+            ),
+            rank = Rank.from(value = "abcdef")
         )
         val expected = Routine(
             id = 1.asID,
@@ -405,7 +467,8 @@ class RoutineDataSourceImplTest {
                     type = TimeType.TIMER,
                     rank = Rank.from(value = "aaaaaa")
                 )
-            )
+            ),
+            rank = Rank.from(value = "abcdef")
         )
 
         database.routineDao().insert(internalRoutine)
@@ -435,7 +498,8 @@ class RoutineDataSourceImplTest {
             name = "name",
             startTimeOffsetInSeconds = 10,
             createdAt = max,
-            updatedAt = max
+            updatedAt = max,
+            rank = "abcdef"
         )
         val routine = Routine(
             id = 1.asID,
@@ -451,7 +515,8 @@ class RoutineDataSourceImplTest {
                     type = TimeType.TIMER,
                     rank = Rank.from(value = "aaaaaa")
                 )
-            )
+            ),
+            rank = Rank.from(value = "abcdef")
         )
         val expected = Routine(
             id = 1.asID,
@@ -467,7 +532,8 @@ class RoutineDataSourceImplTest {
                     type = TimeType.TIMER,
                     rank = Rank.from(value = "aaaaaa")
                 )
-            )
+            ),
+            rank = Rank.from(value = "abcdef")
         )
 
         database.routineDao().insert(internalRoutine)
@@ -506,7 +572,8 @@ class RoutineDataSourceImplTest {
             name = "name",
             startTimeOffsetInSeconds = 10,
             createdAt = max,
-            updatedAt = max
+            updatedAt = max,
+            rank = "abcdef"
         )
         val routine = Routine(
             id = 1.asID,
@@ -529,7 +596,8 @@ class RoutineDataSourceImplTest {
                     type = TimeType.TIMER,
                     rank = Rank.from(value = "bbbbbb")
                 )
-            )
+            ),
+            rank = Rank.from(value = "abcdef")
         )
         val expected = Routine(
             id = 1.asID,
@@ -552,7 +620,8 @@ class RoutineDataSourceImplTest {
                     type = TimeType.TIMER,
                     rank = Rank.from(value = "bbbbbb")
                 )
-            )
+            ),
+            rank = Rank.from(value = "abcdef")
         )
 
         database.routineDao().insert(internalRoutine)
@@ -582,7 +651,8 @@ class RoutineDataSourceImplTest {
             name = "name",
             startTimeOffsetInSeconds = 10,
             createdAt = now,
-            updatedAt = now
+            updatedAt = now,
+            rank = "abcdef"
         )
         val routine = Routine(
             id = 1.asID,
@@ -598,7 +668,8 @@ class RoutineDataSourceImplTest {
                     type = TimeType.TIMER,
                     rank = Rank.from(value = "aaaaaa")
                 )
-            )
+            ),
+            rank = Rank.from(value = "abcdef")
         )
 
         database.routineDao().insert(internalRoutine)

--- a/data/local/database/src/test/java/com/enricog/data/local/database/routines/model/InternalRoutineTest.kt
+++ b/data/local/database/src/test/java/com/enricog/data/local/database/routines/model/InternalRoutineTest.kt
@@ -30,14 +30,16 @@ class InternalRoutineTest {
                     type = TimeType.TIMER,
                     rank = Rank.RANDOM
                 )
-            )
+            ),
+            rank = Rank.from(value = "abcdef")
         )
         val expected = InternalRoutine(
             id = 1,
             name = "name",
             startTimeOffsetInSeconds = 2,
             createdAt = now,
-            updatedAt = now
+            updatedAt = now,
+            rank = "abcdef"
         )
 
         val actual = routine.toInternal()
@@ -63,7 +65,8 @@ class InternalRoutineTest {
             name = "name",
             startTimeOffsetInSeconds = 2,
             createdAt = now,
-            updatedAt = now
+            updatedAt = now,
+            rank = "abcdef"
         )
         val expected = Routine(
             id = 1.asID,
@@ -79,7 +82,8 @@ class InternalRoutineTest {
                     type = TimeType.TIMER,
                     rank = Rank.from("aaaaaa")
                 )
-            )
+            ),
+            rank = Rank.from(value = "abcdef")
         )
 
         val actual = internalRoutine.toEntity(internalSegments)

--- a/data/local/database/src/test/java/com/enricog/data/local/database/routines/model/InternalRoutineWithSegmentsTest.kt
+++ b/data/local/database/src/test/java/com/enricog/data/local/database/routines/model/InternalRoutineWithSegmentsTest.kt
@@ -6,7 +6,6 @@ import com.enricog.data.routines.api.entities.TimeType
 import com.enricog.entities.Rank
 import com.enricog.entities.asID
 import com.enricog.entities.seconds
-import org.junit.Assert
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import java.time.OffsetDateTime
@@ -31,7 +30,8 @@ class InternalRoutineWithSegmentsTest {
             name = "name",
             startTimeOffsetInSeconds = 2,
             createdAt = now,
-            updatedAt = now
+            updatedAt = now,
+            rank = "abcdef"
         )
         val expected = Routine(
             id = 1.asID,
@@ -47,7 +47,8 @@ class InternalRoutineWithSegmentsTest {
                     type = TimeType.TIMER,
                     rank = Rank.from("aaaaaa")
                 )
-            )
+            ),
+            rank = Rank.from(value = "abcdef")
         )
         val internalRoutineWithSegments = InternalRoutineWithSegments(
             routine = internalRoutine,

--- a/data/local/database/src/test/java/com/enricog/data/local/database/routines/model/InternalSegmentTest.kt
+++ b/data/local/database/src/test/java/com/enricog/data/local/database/routines/model/InternalSegmentTest.kt
@@ -18,7 +18,7 @@ class InternalSegmentTest {
             name = "name",
             time = 3.seconds,
             type = TimeType.TIMER,
-            rank = Rank.from("aaaaaa")
+            rank = Rank.from(value = "aaaaaa")
         )
         val expected = InternalSegment(
             id = 2,
@@ -49,7 +49,7 @@ class InternalSegmentTest {
             name = "name",
             time = 3.seconds,
             type = TimeType.TIMER,
-            rank = Rank.from("aaaaaa")
+            rank = Rank.from(value = "aaaaaa")
         )
 
         val result = internalSegment.toEntity()

--- a/data/routines/api/src/main/java/com/enricog/data/routines/api/RoutineDataSource.kt
+++ b/data/routines/api/src/main/java/com/enricog/data/routines/api/RoutineDataSource.kt
@@ -10,6 +10,8 @@ interface RoutineDataSource {
 
     fun observe(id: ID): Flow<Routine>
 
+    suspend fun getAll(): List<Routine>
+
     suspend fun get(id: ID): Routine
 
     suspend fun create(routine: Routine): ID

--- a/data/routines/api/src/main/java/com/enricog/data/routines/api/entities/Routine.kt
+++ b/data/routines/api/src/main/java/com/enricog/data/routines/api/entities/Routine.kt
@@ -12,7 +12,8 @@ data class Routine(
     val startTimeOffset: Seconds,
     val createdAt: OffsetDateTime,
     val updatedAt: OffsetDateTime,
-    val segments: List<Segment>
+    val segments: List<Segment>,
+    val rank: Rank
 ) {
 
     init {
@@ -35,19 +36,23 @@ data class Routine(
     }
 
     companion object {
-        val NEW: Routine
-            get() {
-                val now = OffsetDateTime.now()
-                return Routine(
-                    id = ID.new(),
-                    name = "",
-                    startTimeOffset = 0.seconds,
-                    createdAt = now,
-                    updatedAt = now,
-                    segments = emptyList()
-                )
-            }
+        fun create(rank: Rank): Routine {
+            val now = OffsetDateTime.now()
+            return Routine(
+                id = ID.new(),
+                name = "",
+                startTimeOffset = 0.seconds,
+                createdAt = now,
+                updatedAt = now,
+                segments = emptyList(),
+                rank = rank
+            )
+        }
 
         val MAX_START_TIME_OFFSET = 60.seconds
     }
+}
+
+fun List<Routine>.sortedByRank(): List<Routine> {
+    return sortedBy { it.rank }
 }

--- a/data/routines/api/src/main/java/com/enricog/data/routines/api/entities/Routine.kt
+++ b/data/routines/api/src/main/java/com/enricog/data/routines/api/entities/Routine.kt
@@ -30,7 +30,7 @@ data class Routine(
 
     fun getNewSegmentRank(): Rank {
         return when {
-            segments.isEmpty() -> Rank.calculateFist()
+            segments.isEmpty() -> Rank.calculateFirst()
             else -> Rank.calculateBottom(segments.last().rank)
         }
     }

--- a/data/routines/api/src/main/java/com/enricog/data/routines/api/entities/Segment.kt
+++ b/data/routines/api/src/main/java/com/enricog/data/routines/api/entities/Segment.kt
@@ -38,7 +38,3 @@ data class Segment(
 fun List<Segment>.sortedByRank(): List<Segment> {
     return sortedBy { it.rank }
 }
-
-fun List<Segment>.sortedByRankDescending(): List<Segment> {
-    return sortedByDescending { it.rank }
-}

--- a/data/routines/api/src/test/java/com/enricog/data/routines/api/entities/RoutineTest.kt
+++ b/data/routines/api/src/test/java/com/enricog/data/routines/api/entities/RoutineTest.kt
@@ -1,6 +1,7 @@
 package com.enricog.data.routines.api.entities
 
 import com.enricog.data.routines.api.entities.Routine.Companion.MAX_START_TIME_OFFSET
+import com.enricog.entities.Rank
 import com.enricog.entities.asID
 import com.enricog.entities.seconds
 import java.time.OffsetDateTime
@@ -26,7 +27,8 @@ class RoutineTest {
             startTimeOffset = startTimeOffset,
             createdAt = OffsetDateTime.MAX,
             updatedAt = OffsetDateTime.MAX,
-            segments = emptyList()
+            segments = emptyList(),
+            rank = Rank.from("aaaaaa")
         )
     }
 
@@ -43,7 +45,8 @@ class RoutineTest {
             startTimeOffset = startTimeOffset,
             createdAt = OffsetDateTime.MAX,
             updatedAt = OffsetDateTime.MAX,
-            segments = emptyList()
+            segments = emptyList(),
+            rank = Rank.from("aaaaaa")
         )
     }
 
@@ -61,7 +64,8 @@ class RoutineTest {
             startTimeOffset = 50.seconds,
             createdAt = OffsetDateTime.MAX,
             updatedAt = OffsetDateTime.MAX,
-            segments = emptyList()
+            segments = emptyList(),
+            rank = Rank.from("aaaaaa")
         )
         routine.copy(startTimeOffset = startTimeOffset)
     }
@@ -80,7 +84,8 @@ class RoutineTest {
             startTimeOffset = 50.seconds,
             createdAt = OffsetDateTime.MAX,
             updatedAt = OffsetDateTime.MAX,
-            segments = emptyList()
+            segments = emptyList(),
+            rank = Rank.from("aaaaaa")
         )
         routine.copy(startTimeOffset = startTimeOffset)
     }
@@ -93,7 +98,8 @@ class RoutineTest {
             startTimeOffset = MAX_START_TIME_OFFSET,
             createdAt = OffsetDateTime.MAX,
             updatedAt = OffsetDateTime.MAX,
-            segments = emptyList()
+            segments = emptyList(),
+            rank = Rank.from("aaaaaa")
         )
     }
 
@@ -106,7 +112,8 @@ class RoutineTest {
             startTimeOffset = 50.seconds,
             createdAt = OffsetDateTime.MAX,
             updatedAt = OffsetDateTime.MAX,
-            segments = emptyList()
+            segments = emptyList(),
+            rank = Rank.from("aaaaaa")
         )
         routine.copy(startTimeOffset = MAX_START_TIME_OFFSET)
     }

--- a/data/routines/testing/src/main/java/com/enricog/data/routines/testing/FakeRoutineDataSource.kt
+++ b/data/routines/testing/src/main/java/com/enricog/data/routines/testing/FakeRoutineDataSource.kt
@@ -15,7 +15,9 @@ class FakeRoutineDataSource(
 ) : RoutineDataSource {
 
     override fun observeAll(): Flow<List<Routine>> {
-        return store.asFlow().map { it.orderSegments() }
+        return store.asFlow()
+            .map { it.orderSegments() }
+            .map { it.sortedByRank() }
     }
 
     override fun observe(id: ID): Flow<Routine> {
@@ -25,7 +27,7 @@ class FakeRoutineDataSource(
     }
 
     override suspend fun getAll(): List<Routine> {
-        return store.get()
+        return store.get().sortedByRank()
     }
 
     override suspend fun get(id: ID): Routine {

--- a/data/routines/testing/src/main/java/com/enricog/data/routines/testing/FakeRoutineDataSource.kt
+++ b/data/routines/testing/src/main/java/com/enricog/data/routines/testing/FakeRoutineDataSource.kt
@@ -24,6 +24,10 @@ class FakeRoutineDataSource(
             .map { it.orderSegments() }
     }
 
+    override suspend fun getAll(): List<Routine> {
+        return store.get()
+    }
+
     override suspend fun get(id: ID): Routine {
         return store.get()
             .first { it.id == id }

--- a/data/routines/testing/src/main/java/com/enricog/data/routines/testing/entities/RoutineExtensions.kt
+++ b/data/routines/testing/src/main/java/com/enricog/data/routines/testing/entities/RoutineExtensions.kt
@@ -1,6 +1,7 @@
 package com.enricog.data.routines.testing.entities
 
 import com.enricog.data.routines.api.entities.Routine
+import com.enricog.entities.Rank
 import com.enricog.entities.asID
 import com.enricog.entities.seconds
 import java.time.OffsetDateTime
@@ -14,5 +15,6 @@ val Routine.Companion.EMPTY: Routine
         startTimeOffset = 0.seconds,
         createdAt = OffsetDateTime.of(2020, 12, 20, 10, 10, 0, 0, ZoneOffset.UTC),
         updatedAt = OffsetDateTime.of(2020, 12, 20, 10, 10, 0, 0, ZoneOffset.UTC),
-        segments = emptyList()
+        segments = emptyList(),
+        rank = Rank.from(value = "aaaaaa")
     )

--- a/entities/src/main/java/com/enricog/entities/Rank.kt
+++ b/entities/src/main/java/com/enricog/entities/Rank.kt
@@ -3,6 +3,11 @@ package com.enricog.entities
 import java.lang.IllegalStateException
 import kotlin.math.pow
 
+/**
+ * Lexorank based implementation simplified.
+ * It is used to order items in the databased without changing all items
+ * but only the item that has been moved.
+ */
 @JvmInline
 value class Rank private constructor(private val value: String) : Comparable<Rank> {
 
@@ -32,12 +37,12 @@ value class Rank private constructor(private val value: String) : Comparable<Ran
             return Rank(value)
         }
 
-        fun calculate(rank1: Rank?, rank2: Rank?): Rank {
+        fun calculate(rankTop: Rank?, rankBottom: Rank?): Rank {
             return when {
-                rank1 == null && rank2 != null -> calculateTop(rank2)
-                rank1 != null && rank2 == null -> calculateBottom(rank1)
-                rank1 != null && rank2 != null -> calculate(rank1, rank2)
-                rank1 == null && rank2 == null -> calculateFist()
+                rankTop == null && rankBottom != null -> calculateTop(rankBottom)
+                rankTop != null && rankBottom == null -> calculateBottom(rankTop)
+                rankTop != null && rankBottom != null -> calculate(rankTop, rankBottom)
+                rankTop == null && rankBottom == null -> calculateFist()
                 else -> throw IllegalStateException("Is this life?")
             }
         }
@@ -46,33 +51,33 @@ value class Rank private constructor(private val value: String) : Comparable<Ran
          * Calculate the rank of the very first item of the list.
          */
         fun calculateFist(): Rank {
-            return calculate(rank1 = MIN_RANK, rank2 = MAX_RANK)
+            return calculate(rankTop = MIN_RANK, rankBottom = MAX_RANK)
         }
 
         /**
          * Calculate the rank for the fist item of the list.
          */
         fun calculateTop(rank: Rank): Rank {
-            return calculate(rank1 = MIN_RANK, rank2 = rank)
+            return calculate(rankTop = MIN_RANK, rankBottom = rank)
         }
 
         /**
          * Calculate the rank for the last item of the list.
          */
         fun calculateBottom(rank: Rank): Rank {
-            return calculate(rank1 = rank, rank2 = MAX_RANK)
+            return calculate(rankTop = rank, rankBottom = MAX_RANK)
         }
 
         /**
          * Calculate the rank between two other ranks
          */
-        fun calculate(rank1: Rank, rank2: Rank): Rank {
-            if (rank1 >= rank2) {
-                throw IllegalArgumentException("$rank1 is higher or equal to $rank2")
+        fun calculate(rankTop: Rank, rankBottom: Rank): Rank {
+            if (rankTop >= rankBottom) {
+                throw IllegalArgumentException("RankTop($rankTop) is higher or equal to RankBottom($rankBottom)")
             }
 
-            val codePoints1 = rank1.value.codePoints().toArray()
-            val codePoints2 = rank2.value.codePoints().toArray()
+            val codePoints1 = rankTop.value.codePoints().toArray()
+            val codePoints2 = rankBottom.value.codePoints().toArray()
 
             var diff = 0.0
             for (i in RANK_LENGTH - 1 downTo 0) {
@@ -89,7 +94,7 @@ value class Rank private constructor(private val value: String) : Comparable<Ran
             }
 
             if (diff <= 1) {
-                return from(rank1.value + Char(MIN_CHAR.code + ALPHABET_SIZE / 2).toString())
+                return from(rankTop.value + Char(MIN_CHAR.code + ALPHABET_SIZE / 2).toString())
             }
 
             diff /= 2
@@ -99,7 +104,7 @@ value class Rank private constructor(private val value: String) : Comparable<Ran
                 for (i in 0 until RANK_LENGTH) {
                     val diffInSymbols = (diff / ALPHABET_SIZE.toDouble().pow(i) % ALPHABET_SIZE)
                         .toInt()
-                    var elementCode = rank1.value
+                    var elementCode = rankTop.value
                         .codePointAt(RANK_LENGTH - i - 1) + diffInSymbols + offset
                     offset = 0
                     if (elementCode > MAX_CHAR.code) {

--- a/entities/src/main/java/com/enricog/entities/Rank.kt
+++ b/entities/src/main/java/com/enricog/entities/Rank.kt
@@ -1,6 +1,5 @@
 package com.enricog.entities
 
-import java.lang.IllegalStateException
 import kotlin.math.pow
 
 /**
@@ -42,15 +41,15 @@ value class Rank private constructor(private val value: String) : Comparable<Ran
                 rankTop == null && rankBottom != null -> calculateTop(rankBottom)
                 rankTop != null && rankBottom == null -> calculateBottom(rankTop)
                 rankTop != null && rankBottom != null -> calculate(rankTop, rankBottom)
-                rankTop == null && rankBottom == null -> calculateFist()
-                else -> throw IllegalStateException("Is this life?")
+                // else is same as rankTop == null && rankBottom == null
+                else -> calculateFirst()
             }
         }
 
         /**
          * Calculate the rank of the very first item of the list.
          */
-        fun calculateFist(): Rank {
+        fun calculateFirst(): Rank {
             return calculate(rankTop = MIN_RANK, rankBottom = MAX_RANK)
         }
 

--- a/entities/src/test/java/com/enricog/entities/RankTest.kt
+++ b/entities/src/test/java/com/enricog/entities/RankTest.kt
@@ -11,7 +11,7 @@ class RankTest {
     fun `calculateFist should return middle rank`() {
         val expected = Rank.from("mzzzzz")
 
-        val actual = Rank.calculateFist()
+        val actual = Rank.calculateFirst()
 
         assertEquals(expected, actual)
     }

--- a/entities/src/test/java/com/enricog/entities/RankTest.kt
+++ b/entities/src/test/java/com/enricog/entities/RankTest.kt
@@ -42,7 +42,7 @@ class RankTest {
         val rank2 = Rank.from("cccccc")
         val expected = Rank.from("bbbbbb")
 
-        val actual = Rank.calculate(rank1 = rank1, rank2 = rank2)
+        val actual = Rank.calculate(rankTop = rank1, rankBottom = rank2)
 
         assertEquals(expected, actual)
     }
@@ -65,7 +65,7 @@ class RankTest {
         val rank1 = Rank.from("cccccc")
         val rank2 = Rank.from("aaaaaa")
 
-        Rank.calculate(rank1 = rank1, rank2 = rank2)
+        Rank.calculate(rankTop = rank1, rankBottom = rank2)
     }
 
     @Test(expected = IllegalArgumentException::class)
@@ -73,6 +73,6 @@ class RankTest {
         val rank1 = Rank.from("aaaaaa")
         val rank2 = Rank.from("aaaaaa")
 
-        Rank.calculate(rank1 = rank1, rank2 = rank2)
+        Rank.calculate(rankTop = rank1, rankBottom = rank2)
     }
 }

--- a/features/routines/src/androidTest/java/com/enricog/features/routines/list/RoutinesScreenKtTest.kt
+++ b/features/routines/src/androidTest/java/com/enricog/features/routines/list/RoutinesScreenKtTest.kt
@@ -66,7 +66,7 @@ class RoutinesScreenKtTest {
 
     @Test
     fun shouldRenderRoutinesSceneWhenStateIsData() = composeRule {
-        val viewState = RoutinesViewState.Data(routines = emptyImmutableList(), message = null)
+        val viewState = RoutinesViewState.Data(routinesItems = emptyImmutableList(), message = null)
 
         setContent {
             TempoTheme {

--- a/features/routines/src/androidTest/java/com/enricog/features/routines/list/RoutinesScreenKtTest.kt
+++ b/features/routines/src/androidTest/java/com/enricog/features/routines/list/RoutinesScreenKtTest.kt
@@ -28,6 +28,7 @@ class RoutinesScreenKtTest {
                     onCreateRoutine = {},
                     onRoutine = {},
                     onRoutineDelete = {},
+                    onRoutineMoved = { _, _ -> },
                     onRetryLoad = {},
                     onSnackbarEvent = {}
                 )
@@ -51,6 +52,7 @@ class RoutinesScreenKtTest {
                     onCreateRoutine = {},
                     onRoutine = {},
                     onRoutineDelete = {},
+                    onRoutineMoved = { _, _ -> },
                     onRetryLoad = {},
                     onSnackbarEvent = {}
                 )
@@ -74,6 +76,7 @@ class RoutinesScreenKtTest {
                     onCreateRoutine = {},
                     onRoutine = {},
                     onRoutineDelete = {},
+                    onRoutineMoved = { _, _ -> },
                     onRetryLoad = {},
                     onSnackbarEvent = {}
                 )
@@ -98,6 +101,7 @@ class RoutinesScreenKtTest {
                     onCreateRoutine = {},
                     onRoutine = {},
                     onRoutineDelete = {},
+                    onRoutineMoved = { _, _ -> },
                     onRetryLoad = {},
                     onSnackbarEvent = {}
                 )

--- a/features/routines/src/main/java/com/enricog/features/routines/detail/routine/usecase/RoutineUseCase.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/detail/routine/usecase/RoutineUseCase.kt
@@ -13,9 +13,9 @@ internal class RoutineUseCase @Inject constructor(
     suspend fun get(routineId: ID): Routine {
         return when {
             routineId.isNew -> {
-                val topRoutine = routineDataSource.getAll().firstOrNull()
-                val rank = if (topRoutine == null) Rank.calculateFirst() else
-                    Rank.calculateTop(rank = topRoutine.rank)
+                val firstRoutine = routineDataSource.getAll().firstOrNull()
+                val rank = if (firstRoutine == null) Rank.calculateFirst() else
+                    Rank.calculateTop(rank = firstRoutine.rank)
                 Routine.create(rank = rank)
             }
             else -> routineDataSource.get(routineId)

--- a/features/routines/src/main/java/com/enricog/features/routines/detail/routine/usecase/RoutineUseCase.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/detail/routine/usecase/RoutineUseCase.kt
@@ -3,6 +3,7 @@ package com.enricog.features.routines.detail.routine.usecase
 import com.enricog.data.routines.api.RoutineDataSource
 import com.enricog.data.routines.api.entities.Routine
 import com.enricog.entities.ID
+import com.enricog.entities.Rank
 import javax.inject.Inject
 
 internal class RoutineUseCase @Inject constructor(
@@ -11,7 +12,12 @@ internal class RoutineUseCase @Inject constructor(
 
     suspend fun get(routineId: ID): Routine {
         return when {
-            routineId.isNew -> Routine.NEW
+            routineId.isNew -> {
+                val topRoutine = routineDataSource.getAll().firstOrNull()
+                val rank = if (topRoutine == null) Rank.calculateFist() else
+                    Rank.calculateTop(rank = topRoutine.rank)
+                Routine.create(rank = rank)
+            }
             else -> routineDataSource.get(routineId)
         }
     }

--- a/features/routines/src/main/java/com/enricog/features/routines/detail/routine/usecase/RoutineUseCase.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/detail/routine/usecase/RoutineUseCase.kt
@@ -14,7 +14,7 @@ internal class RoutineUseCase @Inject constructor(
         return when {
             routineId.isNew -> {
                 val topRoutine = routineDataSource.getAll().firstOrNull()
-                val rank = if (topRoutine == null) Rank.calculateFist() else
+                val rank = if (topRoutine == null) Rank.calculateFirst() else
                     Rank.calculateTop(rank = topRoutine.rank)
                 Routine.create(rank = rank)
             }

--- a/features/routines/src/main/java/com/enricog/features/routines/detail/summary/RoutineSummaryReducer.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/detail/summary/RoutineSummaryReducer.kt
@@ -26,7 +26,7 @@ internal class RoutineSummaryReducer @Inject constructor() {
         return state.copy(action = DeleteSegmentError(segmentId = segmentId))
     }
 
-    fun segmentMoveError(state: RoutineSummaryState.Data): RoutineSummaryState.Data {
+    fun moveSegmentError(state: RoutineSummaryState.Data): RoutineSummaryState.Data {
         return state.copy(action = MoveSegmentError)
     }
 

--- a/features/routines/src/main/java/com/enricog/features/routines/detail/summary/RoutineSummaryScreen.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/detail/summary/RoutineSummaryScreen.kt
@@ -34,7 +34,7 @@ internal fun RoutineSummaryViewState.Compose(
     onSegmentAdd: () -> Unit,
     onSegmentSelected: (ID) -> Unit,
     onSegmentDelete: (ID) -> Unit,
-    onSegmentMoved: (ID, ID?) -> Unit,
+    onSegmentMoved: (ID, ID) -> Unit,
     onRoutineStart: () -> Unit,
     onRoutineEdit: () -> Unit,
     onRetryLoad: () -> Unit,

--- a/features/routines/src/main/java/com/enricog/features/routines/detail/summary/RoutineSummaryViewModel.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/detail/summary/RoutineSummaryViewModel.kt
@@ -95,7 +95,7 @@ internal class RoutineSummaryViewModel @Inject constructor(
     fun onSegmentMoved(draggedSegmentId: ID, hoveredSegmentId: ID?) {
         val exceptionHandler = CoroutineExceptionHandler { _, throwable ->
             TempoLogger.e(throwable = throwable)
-            updateStateWhen<RoutineSummaryState.Data> { reducer.segmentMoveError(state = it) }
+            updateStateWhen<RoutineSummaryState.Data> { reducer.moveSegmentError(state = it) }
         }
         moveJob = launchWhen<RoutineSummaryState.Data>(exceptionHandler) {
             moveSegmentUseCase(

--- a/features/routines/src/main/java/com/enricog/features/routines/detail/summary/RoutineSummaryViewModel.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/detail/summary/RoutineSummaryViewModel.kt
@@ -92,7 +92,7 @@ internal class RoutineSummaryViewModel @Inject constructor(
         }
     }
 
-    fun onSegmentMoved(draggedSegmentId: ID, hoveredSegmentId: ID?) {
+    fun onSegmentMoved(draggedSegmentId: ID, hoveredSegmentId: ID) {
         val exceptionHandler = CoroutineExceptionHandler { _, throwable ->
             TempoLogger.e(throwable = throwable)
             updateStateWhen<RoutineSummaryState.Data> { reducer.moveSegmentError(state = it) }

--- a/features/routines/src/main/java/com/enricog/features/routines/detail/summary/models/RoutineSummaryItem.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/detail/summary/models/RoutineSummaryItem.kt
@@ -8,13 +8,19 @@ import com.enricog.features.routines.detail.ui.time_type.TimeType
 
 internal sealed class RoutineSummaryItem {
 
+    abstract val isDraggable: Boolean
+
     data class RoutineInfo(
         val routineName: String
-    ) : RoutineSummaryItem()
+    ) : RoutineSummaryItem() {
+        override val isDraggable: Boolean = false
+    }
 
     data class SegmentSectionTitle(
         @Stable val error: Pair<RoutineSummaryField.Segments, Int>?
-    ) : RoutineSummaryItem()
+    ) : RoutineSummaryItem() {
+        override val isDraggable: Boolean = false
+    }
 
     data class SegmentItem(
         @Stable val id: ID,
@@ -23,6 +29,7 @@ internal sealed class RoutineSummaryItem {
         val type: TimeType,
         val rank: String
     ) : RoutineSummaryItem() {
+        override val isDraggable: Boolean = true
 
         companion object {
             fun from(segment: Segment) = SegmentItem(
@@ -35,5 +42,7 @@ internal sealed class RoutineSummaryItem {
         }
     }
 
-    object Space : RoutineSummaryItem()
+    object Space : RoutineSummaryItem() {
+        override val isDraggable: Boolean = false
+    }
 }

--- a/features/routines/src/main/java/com/enricog/features/routines/detail/summary/ui_components/RoutineSummaryScene.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/detail/summary/ui_components/RoutineSummaryScene.kt
@@ -122,8 +122,8 @@ internal fun RoutineSummaryScene(
         anchor = {
             AnimatedVisibility(
                 visible = !listDraggableState.isDragging,
-                enter = slideInVertically(initialOffsetY = { it }),
-                exit = slideOutVertically(targetOffsetY = { it }),
+                enter = slideInVertically(initialOffsetY = { it * 2 }),
+                exit = slideOutVertically(targetOffsetY = { it * 2}),
                 modifier = Modifier.fillMaxWidth()
             ) {
                 Box(modifier = Modifier.fillMaxWidth()) {

--- a/features/routines/src/main/java/com/enricog/features/routines/detail/summary/ui_components/RoutineSummaryScene.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/detail/summary/ui_components/RoutineSummaryScene.kt
@@ -41,7 +41,7 @@ internal fun RoutineSummaryScene(
     onSegmentAdd: () -> Unit,
     onSegmentSelected: (ID) -> Unit,
     onSegmentDelete: (ID) -> Unit,
-    onSegmentMoved: (ID, ID?) -> Unit,
+    onSegmentMoved: (ID, ID) -> Unit,
     onRoutineStart: () -> Unit,
     onRoutineEdit: () -> Unit,
     onSnackbarEvent: (TempoSnackbarEvent) -> Unit
@@ -66,8 +66,8 @@ internal fun RoutineSummaryScene(
         listDraggableState.itemMovedEvent.collect { itemMoved ->
             val draggedSegment = summaryItems[itemMoved.indexDraggedItem] as? SegmentItem
             val hoveredSegment = summaryItems[itemMoved.indexHoveredItem] as? SegmentItem
-            if (draggedSegment != null) {
-                onSegmentMoved(draggedSegment.id, hoveredSegment?.id)
+            if (draggedSegment != null && hoveredSegment != null) {
+                onSegmentMoved(draggedSegment.id, hoveredSegment.id)
             }
         }
     }

--- a/features/routines/src/main/java/com/enricog/features/routines/detail/summary/ui_components/RoutineSummaryScene.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/detail/summary/ui_components/RoutineSummaryScene.kt
@@ -49,7 +49,7 @@ internal fun RoutineSummaryScene(
 
     val listDraggableState = rememberListDraggableState(
         key = summaryItems,
-        isItemDraggable = { index -> summaryItems[index] is SegmentItem }
+        isItemDraggable = { index -> summaryItems[index].isDraggable }
     )
     val snackbarHostState = rememberSnackbarHostState()
 

--- a/features/routines/src/main/java/com/enricog/features/routines/detail/summary/ui_components/RoutineSummaryScene.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/detail/summary/ui_components/RoutineSummaryScene.kt
@@ -113,8 +113,8 @@ internal fun RoutineSummaryScene(
                 if (listDraggableState.isDragging) {
                     DraggedSegment(
                         modifier = Modifier.padding(horizontal = TempoTheme.dimensions.spaceM),
-                        segment = summaryItems[listDraggableState.draggedItem?.index!!] as SegmentItem,
-                        offset = listDraggableState.draggedItemOffsetY
+                        segment = summaryItems[listDraggableState.draggedItem!!.index] as SegmentItem,
+                        offsetProvider = { listDraggableState.draggedItemOffsetY }
                     )
                 }
             }

--- a/features/routines/src/main/java/com/enricog/features/routines/detail/summary/ui_components/SummaryList.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/detail/summary/ui_components/SummaryList.kt
@@ -69,7 +69,7 @@ internal fun SummaryList(
                         when {
                             draggedItem.index == hoveredIndex -> 0f
                             index in (draggedItem.index + 1)..hoveredIndex -> itemHeight.times(-1)
-                            index in (hoveredIndex + 1) until draggedItem.index -> itemHeight
+                            index in hoveredIndex until draggedItem.index -> itemHeight
                             else -> 0f
                         }
                     } ?: 0f

--- a/features/routines/src/main/java/com/enricog/features/routines/detail/summary/usecase/MoveSegmentUseCase.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/detail/summary/usecase/MoveSegmentUseCase.kt
@@ -10,11 +10,13 @@ internal class MoveSegmentUseCase @Inject constructor(
     private val routineDataSource: RoutineDataSource
 ) {
 
-    suspend operator fun invoke(routine: Routine, draggedSegmentId: ID, hoveredSegmentId: ID?) {
+    suspend operator fun invoke(routine: Routine, draggedSegmentId: ID, hoveredSegmentId: ID) {
         val currentIndex = routine.segments.indexOfFirst { it.id == draggedSegmentId }
+            .takeIf { it >= 0 } ?: return
         val newIndex = routine.segments.indexOfFirst { it.id == hoveredSegmentId }
+            .takeIf { it >= 0 } ?: return
 
-        if (currentIndex == newIndex || currentIndex < 0) {
+        if (currentIndex == newIndex) {
             return
         }
 

--- a/features/routines/src/main/java/com/enricog/features/routines/detail/summary/usecase/MoveSegmentUseCase.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/detail/summary/usecase/MoveSegmentUseCase.kt
@@ -11,16 +11,16 @@ internal class MoveSegmentUseCase @Inject constructor(
 ) {
 
     suspend operator fun invoke(routine: Routine, draggedSegmentId: ID, hoveredSegmentId: ID?) {
-        val itemIndex = routine.segments.indexOfFirst { it.id == draggedSegmentId }
+        val currentIndex = routine.segments.indexOfFirst { it.id == draggedSegmentId }
         val newIndex = routine.segments.indexOfFirst { it.id == hoveredSegmentId }
 
-        if (itemIndex == newIndex || itemIndex < 0) {
+        if (currentIndex == newIndex || currentIndex < 0) {
             return
         }
 
-        val rank1 = routine.segments.getOrNull(newIndex)?.rank
-        val rank2 = routine.segments.getOrNull(newIndex + 1)?.rank
-        val newRank = Rank.calculate(rank1 = rank1, rank2 = rank2)
+        val rankTop = routine.segments.getOrNull(newIndex)?.rank
+        val rankBottom = routine.segments.getOrNull(newIndex + 1)?.rank
+        val newRank = Rank.calculate(rankTop = rankTop, rankBottom = rankBottom)
         val segments = routine.segments
             .map {
                 if (it.id == draggedSegmentId) {

--- a/features/routines/src/main/java/com/enricog/features/routines/detail/summary/usecase/MoveSegmentUseCase.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/detail/summary/usecase/MoveSegmentUseCase.kt
@@ -18,8 +18,13 @@ internal class MoveSegmentUseCase @Inject constructor(
             return
         }
 
-        val rankTop = routine.segments.getOrNull(newIndex)?.rank
-        val rankBottom = routine.segments.getOrNull(newIndex + 1)?.rank
+        fun getRank(index: Int): Rank? = routine.segments.getOrNull(index)?.rank
+
+        val (rankTop, rankBottom) = if (currentIndex > newIndex) {
+            getRank(index = newIndex - 1) to getRank(index = newIndex)
+        } else {
+            getRank(index = newIndex) to getRank(index = newIndex + 1)
+        }
         val newRank = Rank.calculate(rankTop = rankTop, rankBottom = rankBottom)
         val segments = routine.segments
             .map {

--- a/features/routines/src/main/java/com/enricog/features/routines/list/RoutinesReducer.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/list/RoutinesReducer.kt
@@ -4,6 +4,7 @@ import com.enricog.data.routines.api.entities.Routine
 import com.enricog.entities.ID
 import com.enricog.features.routines.list.models.RoutinesState
 import com.enricog.features.routines.list.models.RoutinesState.Data.Action.DeleteRoutineError
+import com.enricog.features.routines.list.models.RoutinesState.Data.Action.MoveRoutineError
 import javax.inject.Inject
 
 internal class RoutinesReducer @Inject constructor() {
@@ -22,6 +23,10 @@ internal class RoutinesReducer @Inject constructor() {
 
     fun deleteRoutineError(state: RoutinesState.Data, routineId: ID): RoutinesState.Data {
         return state.copy(action = DeleteRoutineError(routineId = routineId))
+    }
+
+    fun moveRoutineError(state: RoutinesState.Data): RoutinesState.Data {
+        return state.copy(action = MoveRoutineError)
     }
 
     fun actionHandled(state: RoutinesState.Data): RoutinesState.Data {

--- a/features/routines/src/main/java/com/enricog/features/routines/list/RoutinesScreen.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/list/RoutinesScreen.kt
@@ -4,7 +4,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.res.stringResource
-import com.enricog.data.routines.api.entities.Routine
 import com.enricog.entities.ID
 import com.enricog.features.routines.R
 import com.enricog.features.routines.list.models.RoutinesViewState
@@ -25,6 +24,7 @@ internal fun RoutinesScreen(viewModel: RoutinesViewModel) {
             onCreateRoutine = viewModel::onCreateRoutine,
             onRoutine = viewModel::onRoutine,
             onRoutineDelete = viewModel::onRoutineDelete,
+            onRoutineMoved = viewModel::onRoutineMoved,
             onRetryLoad = viewModel::onRetryLoad,
             onSnackbarEvent = viewModel::onSnackbarEvent
         )
@@ -36,6 +36,7 @@ internal fun RoutinesViewState.Compose(
     onCreateRoutine: () -> Unit,
     onRoutine: (ID) -> Unit,
     onRoutineDelete: (ID) -> Unit,
+    onRoutineMoved: (ID, ID?) -> Unit,
     onRetryLoad: () -> Unit,
     onSnackbarEvent: (TempoSnackbarEvent) -> Unit
 ) {
@@ -52,6 +53,7 @@ internal fun RoutinesViewState.Compose(
                 onRoutine = onRoutine,
                 onRoutineDelete = onRoutineDelete,
                 onCreateRoutine = onCreateRoutine,
+                onRoutineMoved = onRoutineMoved,
                 onSnackbarEvent = onSnackbarEvent
             )
         is RoutinesViewState.Error ->

--- a/features/routines/src/main/java/com/enricog/features/routines/list/RoutinesScreen.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/list/RoutinesScreen.kt
@@ -48,7 +48,7 @@ internal fun RoutinesViewState.Compose(
             )
         is RoutinesViewState.Data ->
             RoutinesScene(
-                routines = routines,
+                routinesItems = routinesItems,
                 message = message,
                 onRoutine = onRoutine,
                 onRoutineDelete = onRoutineDelete,

--- a/features/routines/src/main/java/com/enricog/features/routines/list/RoutinesScreen.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/list/RoutinesScreen.kt
@@ -36,7 +36,7 @@ internal fun RoutinesViewState.Compose(
     onCreateRoutine: () -> Unit,
     onRoutine: (ID) -> Unit,
     onRoutineDelete: (ID) -> Unit,
-    onRoutineMoved: (ID, ID?) -> Unit,
+    onRoutineMoved: (ID, ID) -> Unit,
     onRetryLoad: () -> Unit,
     onSnackbarEvent: (TempoSnackbarEvent) -> Unit
 ) {

--- a/features/routines/src/main/java/com/enricog/features/routines/list/RoutinesStateConverter.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/list/RoutinesStateConverter.kt
@@ -3,6 +3,8 @@ package com.enricog.features.routines.list
 import com.enricog.base.viewmodel.StateConverter
 import com.enricog.core.compose.api.classes.asImmutableList
 import com.enricog.features.routines.R
+import com.enricog.features.routines.list.models.RoutinesItem.RoutineItem
+import com.enricog.features.routines.list.models.RoutinesItem.Space
 import com.enricog.features.routines.list.models.RoutinesState
 import com.enricog.features.routines.list.models.RoutinesState.Data.Action
 import com.enricog.features.routines.list.models.RoutinesState.Data.Action.DeleteRoutineError
@@ -10,7 +12,6 @@ import com.enricog.features.routines.list.models.RoutinesState.Data.Action.MoveR
 import com.enricog.features.routines.list.models.RoutinesViewState
 import com.enricog.features.routines.list.models.RoutinesViewState.Data
 import com.enricog.features.routines.list.models.RoutinesViewState.Data.Message
-import com.enricog.features.routines.list.models.RoutinesViewState.Data.Routine
 import javax.inject.Inject
 
 internal class RoutinesStateConverter @Inject constructor() :
@@ -21,7 +22,10 @@ internal class RoutinesStateConverter @Inject constructor() :
             RoutinesState.Idle -> RoutinesViewState.Idle
             RoutinesState.Empty -> RoutinesViewState.Empty
             is RoutinesState.Data -> Data(
-                routines = state.routines.map { Routine.from(routine = it) }.asImmutableList(),
+                routinesItems = buildList {
+                    addAll(state.routines.map { RoutineItem.from(routine = it) })
+                    add(Space)
+                }.asImmutableList(),
                 message = state.action?.toMessage()
             )
             is RoutinesState.Error -> RoutinesViewState.Error(throwable = state.throwable)

--- a/features/routines/src/main/java/com/enricog/features/routines/list/RoutinesStateConverter.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/list/RoutinesStateConverter.kt
@@ -6,6 +6,7 @@ import com.enricog.features.routines.R
 import com.enricog.features.routines.list.models.RoutinesState
 import com.enricog.features.routines.list.models.RoutinesState.Data.Action
 import com.enricog.features.routines.list.models.RoutinesState.Data.Action.DeleteRoutineError
+import com.enricog.features.routines.list.models.RoutinesState.Data.Action.MoveRoutineError
 import com.enricog.features.routines.list.models.RoutinesViewState
 import com.enricog.features.routines.list.models.RoutinesViewState.Data
 import com.enricog.features.routines.list.models.RoutinesViewState.Data.Message
@@ -32,6 +33,10 @@ internal class RoutinesStateConverter @Inject constructor() :
             is DeleteRoutineError -> Message(
                 textResId = R.string.label_routines_delete_error,
                 actionTextResId = R.string.action_text_routines_delete_error
+            )
+            MoveRoutineError -> Message(
+                textResId = R.string.label_routines_move_error,
+                actionTextResId = null
             )
         }
     }

--- a/features/routines/src/main/java/com/enricog/features/routines/list/RoutinesViewModel.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/list/RoutinesViewModel.kt
@@ -82,7 +82,7 @@ internal class RoutinesViewModel @Inject constructor(
         }
     }
 
-    fun onRoutineMoved(draggedRoutineId: ID, hoveredRoutineId: ID?) {
+    fun onRoutineMoved(draggedRoutineId: ID, hoveredRoutineId: ID) {
         val exceptionHandler = CoroutineExceptionHandler { _, throwable ->
             TempoLogger.e(throwable = throwable)
             updateStateWhen<RoutinesState.Data> { reducer.moveRoutineError(state = it) }

--- a/features/routines/src/main/java/com/enricog/features/routines/list/RoutinesViewModel.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/list/RoutinesViewModel.kt
@@ -9,7 +9,9 @@ import com.enricog.core.logger.api.TempoLogger
 import com.enricog.entities.ID
 import com.enricog.features.routines.list.models.RoutinesState
 import com.enricog.features.routines.list.models.RoutinesState.Data.Action.DeleteRoutineError
+import com.enricog.features.routines.list.models.RoutinesState.Data.Action.MoveRoutineError
 import com.enricog.features.routines.list.models.RoutinesViewState
+import com.enricog.features.routines.list.usecase.MoveRoutineUseCase
 import com.enricog.features.routines.list.usecase.RoutinesUseCase
 import com.enricog.features.routines.navigation.RoutinesNavigationActions
 import com.enricog.ui.components.snackbar.TempoSnackbarEvent
@@ -29,7 +31,8 @@ internal class RoutinesViewModel @Inject constructor(
     converter: RoutinesStateConverter,
     private val navigationActions: RoutinesNavigationActions,
     private val reducer: RoutinesReducer,
-    private val routinesUseCase: RoutinesUseCase
+    private val routinesUseCase: RoutinesUseCase,
+    private val moveRoutineUseCase: MoveRoutineUseCase
 ) : BaseViewModel<RoutinesState, RoutinesViewState>(
     initialState = RoutinesState.Idle,
     converter = converter,
@@ -38,6 +41,7 @@ internal class RoutinesViewModel @Inject constructor(
 
     private var loadJob by autoCancelableJob()
     private var deleteJob by autoCancelableJob()
+    private var moveJob by autoCancelableJob()
 
     init {
         load()
@@ -78,6 +82,20 @@ internal class RoutinesViewModel @Inject constructor(
         }
     }
 
+    fun onRoutineMoved(draggedRoutineId: ID, hoveredRoutineId: ID?) {
+        val exceptionHandler = CoroutineExceptionHandler { _, throwable ->
+            TempoLogger.e(throwable = throwable)
+            updateStateWhen<RoutinesState.Data> { reducer.moveRoutineError(state = it) }
+        }
+        moveJob = launchWhen<RoutinesState.Data>(exceptionHandler) {
+            moveRoutineUseCase(
+                routines = it.routines,
+                draggedRoutineId = draggedRoutineId,
+                hoveredRoutineId = hoveredRoutineId
+            )
+        }
+    }
+
     fun onRetryLoad() {
         load()
     }
@@ -90,6 +108,7 @@ internal class RoutinesViewModel @Inject constructor(
             if (snackbarEvent == ActionPerformed) {
                 when (previousAction) {
                     is DeleteRoutineError -> onRoutineDelete(routineId = previousAction.routineId)
+                    MoveRoutineError,
                     null -> Unit
                 }
             }

--- a/features/routines/src/main/java/com/enricog/features/routines/list/models/RoutinesItem.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/list/models/RoutinesItem.kt
@@ -1,0 +1,32 @@
+package com.enricog.features.routines.list.models
+
+import androidx.compose.runtime.Stable
+import com.enricog.data.routines.api.entities.Routine
+import com.enricog.entities.ID
+
+internal sealed class RoutinesItem {
+
+    abstract val isDraggable: Boolean
+
+    data class RoutineItem(
+        @Stable val id: ID,
+        val name: String,
+        val rank: String
+    ) : RoutinesItem() {
+
+        override val isDraggable: Boolean = true
+
+        companion object {
+            fun from(routine: Routine) = RoutineItem(
+                id = routine.id,
+                name = routine.name,
+                rank = routine.rank.toString()
+            )
+        }
+    }
+
+
+    object Space : RoutinesItem() {
+        override val isDraggable: Boolean = false
+    }
+}

--- a/features/routines/src/main/java/com/enricog/features/routines/list/models/RoutinesState.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/list/models/RoutinesState.kt
@@ -12,6 +12,7 @@ internal sealed class RoutinesState {
     data class Data(val routines: List<Routine>, val action: Action?) : RoutinesState() {
         sealed class Action {
             data class DeleteRoutineError(val routineId: ID) : Action()
+            object MoveRoutineError: Action()
         }
     }
 

--- a/features/routines/src/main/java/com/enricog/features/routines/list/models/RoutinesViewState.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/list/models/RoutinesViewState.kt
@@ -17,10 +17,18 @@ internal sealed class RoutinesViewState {
         val message: Message?
     ) : RoutinesViewState() {
 
-        data class Routine(@Stable val id: ID, val name: String) {
+        data class Routine(
+            @Stable val id: ID,
+            val name: String,
+            val rank: String
+        ) {
 
             companion object {
-                fun from(routine: RoutineEntity) = Routine(id = routine.id, name = routine.name)
+                fun from(routine: RoutineEntity) = Routine(
+                    id = routine.id,
+                    name = routine.name,
+                    rank = routine.rank.toString()
+                )
             }
         }
 

--- a/features/routines/src/main/java/com/enricog/features/routines/list/models/RoutinesViewState.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/list/models/RoutinesViewState.kt
@@ -1,10 +1,7 @@
 package com.enricog.features.routines.list.models
 
 import androidx.annotation.StringRes
-import androidx.compose.runtime.Stable
 import com.enricog.core.compose.api.classes.ImmutableList
-import com.enricog.entities.ID
-import com.enricog.data.routines.api.entities.Routine as RoutineEntity
 
 internal sealed class RoutinesViewState {
 
@@ -13,25 +10,9 @@ internal sealed class RoutinesViewState {
     object Empty : RoutinesViewState()
 
     data class Data(
-        val routines: ImmutableList<Routine>,
+        val routinesItems: ImmutableList<RoutinesItem>,
         val message: Message?
     ) : RoutinesViewState() {
-
-        data class Routine(
-            @Stable val id: ID,
-            val name: String,
-            val rank: String
-        ) {
-
-            companion object {
-                fun from(routine: RoutineEntity) = Routine(
-                    id = routine.id,
-                    name = routine.name,
-                    rank = routine.rank.toString()
-                )
-            }
-        }
-
         data class Message(@StringRes val textResId: Int, @StringRes val actionTextResId: Int?)
     }
 

--- a/features/routines/src/main/java/com/enricog/features/routines/list/models/RoutinesViewState.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/list/models/RoutinesViewState.kt
@@ -24,7 +24,7 @@ internal sealed class RoutinesViewState {
             }
         }
 
-        data class Message(@StringRes val textResId: Int, @StringRes val actionTextResId: Int)
+        data class Message(@StringRes val textResId: Int, @StringRes val actionTextResId: Int?)
     }
 
     data class Error(val throwable: Throwable) : RoutinesViewState()

--- a/features/routines/src/main/java/com/enricog/features/routines/list/ui_components/DraggedRoutine.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/list/ui_components/DraggedRoutine.kt
@@ -1,4 +1,4 @@
-package com.enricog.features.routines.detail.summary.ui_components
+package com.enricog.features.routines.list.ui_components
 
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
@@ -7,24 +7,23 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.zIndex
-import com.enricog.features.routines.detail.summary.models.RoutineSummaryItem
+import com.enricog.features.routines.list.models.RoutinesViewState
 import com.enricog.ui.theme.TempoTheme
 
-internal const val DraggedSegmentTestTag = "DraggedSegment"
+internal const val DraggedRoutineTestTag = "DraggedRoutineTestTag"
 
 @Composable
-internal fun DraggedSegment(
-    segment: RoutineSummaryItem.SegmentItem,
+internal fun DraggedRoutine(
+    routine: RoutinesViewState.Data.Routine,
     offsetProvider: () -> Float,
     modifier: Modifier = Modifier
 ) {
-    SegmentItem(
-        segment = segment,
-        enableClick = false,
+    RoutineItem(
+        routine = routine,
         onClick = {},
         onDelete = {},
         modifier = modifier
-            .testTag(DraggedSegmentTestTag)
+            .testTag(DraggedRoutineTestTag)
             .fillMaxWidth()
             .graphicsLayer {
                 translationY = offsetProvider()

--- a/features/routines/src/main/java/com/enricog/features/routines/list/ui_components/DraggedRoutine.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/list/ui_components/DraggedRoutine.kt
@@ -7,6 +7,8 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.zIndex
+import com.enricog.features.routines.list.models.RoutinesItem
+import com.enricog.features.routines.list.models.RoutinesItem.RoutineItem
 import com.enricog.features.routines.list.models.RoutinesViewState
 import com.enricog.ui.theme.TempoTheme
 
@@ -14,7 +16,7 @@ internal const val DraggedRoutineTestTag = "DraggedRoutineTestTag"
 
 @Composable
 internal fun DraggedRoutine(
-    routine: RoutinesViewState.Data.Routine,
+    routine: RoutineItem,
     offsetProvider: () -> Float,
     modifier: Modifier = Modifier
 ) {

--- a/features/routines/src/main/java/com/enricog/features/routines/list/ui_components/DraggedRoutine.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/list/ui_components/DraggedRoutine.kt
@@ -22,6 +22,7 @@ internal fun DraggedRoutine(
         routine = routine,
         onClick = {},
         onDelete = {},
+        enableClick = false,
         modifier = modifier
             .testTag(DraggedRoutineTestTag)
             .fillMaxWidth()

--- a/features/routines/src/main/java/com/enricog/features/routines/list/ui_components/DraggedRoutine.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/list/ui_components/DraggedRoutine.kt
@@ -7,9 +7,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.zIndex
-import com.enricog.features.routines.list.models.RoutinesItem
 import com.enricog.features.routines.list.models.RoutinesItem.RoutineItem
-import com.enricog.features.routines.list.models.RoutinesViewState
 import com.enricog.ui.theme.TempoTheme
 
 internal const val DraggedRoutineTestTag = "DraggedRoutineTestTag"
@@ -21,7 +19,7 @@ internal fun DraggedRoutine(
     modifier: Modifier = Modifier
 ) {
     RoutineItem(
-        routine = routine,
+        routineItem = routine,
         onClick = {},
         onDelete = {},
         enableClick = false,

--- a/features/routines/src/main/java/com/enricog/features/routines/list/ui_components/RoutineItem.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/list/ui_components/RoutineItem.kt
@@ -18,6 +18,7 @@ internal const val RoutineItemTestTag = "RoutineItemTestTag"
 internal fun RoutineItem(
     modifier: Modifier = Modifier,
     routine: Routine,
+    enableClick: Boolean,
     onClick: (ID) -> Unit,
     onDelete: (ID) -> Unit
 ) {
@@ -26,7 +27,7 @@ internal fun RoutineItem(
             .testTag(RoutineItemTestTag),
         onDelete = { onDelete(routine.id) }
     ) {
-        Box(modifier = Modifier.clickable { onClick(routine.id) }) {
+        Box(modifier = Modifier.clickable(enabled = enableClick) { onClick(routine.id) }) {
             TempoText(
                 modifier = Modifier.padding(TempoTheme.dimensions.spaceM),
                 text = routine.name,

--- a/features/routines/src/main/java/com/enricog/features/routines/list/ui_components/RoutineItem.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/list/ui_components/RoutineItem.kt
@@ -7,7 +7,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import com.enricog.entities.ID
-import com.enricog.features.routines.list.models.RoutinesViewState.Data.Routine
+import com.enricog.features.routines.list.models.RoutinesItem
+import com.enricog.features.routines.list.models.RoutinesItem.RoutineItem
 import com.enricog.features.routines.ui_components.DeletableListItem
 import com.enricog.ui.components.text.TempoText
 import com.enricog.ui.theme.TempoTheme
@@ -17,7 +18,7 @@ internal const val RoutineItemTestTag = "RoutineItemTestTag"
 @Composable
 internal fun RoutineItem(
     modifier: Modifier = Modifier,
-    routine: Routine,
+    routine: RoutineItem,
     enableClick: Boolean,
     onClick: (ID) -> Unit,
     onDelete: (ID) -> Unit

--- a/features/routines/src/main/java/com/enricog/features/routines/list/ui_components/RoutineItem.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/list/ui_components/RoutineItem.kt
@@ -7,7 +7,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import com.enricog.entities.ID
-import com.enricog.features.routines.list.models.RoutinesItem
 import com.enricog.features.routines.list.models.RoutinesItem.RoutineItem
 import com.enricog.features.routines.ui_components.DeletableListItem
 import com.enricog.ui.components.text.TempoText
@@ -18,7 +17,7 @@ internal const val RoutineItemTestTag = "RoutineItemTestTag"
 @Composable
 internal fun RoutineItem(
     modifier: Modifier = Modifier,
-    routine: RoutineItem,
+    routineItem: RoutineItem,
     enableClick: Boolean,
     onClick: (ID) -> Unit,
     onDelete: (ID) -> Unit
@@ -26,12 +25,12 @@ internal fun RoutineItem(
     DeletableListItem(
         modifier = modifier
             .testTag(RoutineItemTestTag),
-        onDelete = { onDelete(routine.id) }
+        onDelete = { onDelete(routineItem.id) }
     ) {
-        Box(modifier = Modifier.clickable(enabled = enableClick) { onClick(routine.id) }) {
+        Box(modifier = Modifier.clickable(enabled = enableClick) { onClick(routineItem.id) }) {
             TempoText(
                 modifier = Modifier.padding(TempoTheme.dimensions.spaceM),
-                text = routine.name,
+                text = routineItem.name,
                 style = TempoTheme.typography.h2
             )
         }

--- a/features/routines/src/main/java/com/enricog/features/routines/list/ui_components/RoutinesScene.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/list/ui_components/RoutinesScene.kt
@@ -48,7 +48,7 @@ internal fun RoutinesScene(
     onRoutine: (ID) -> Unit,
     onRoutineDelete: (ID) -> Unit,
     onCreateRoutine: () -> Unit,
-    onRoutineMoved: (ID, ID?) -> Unit,
+    onRoutineMoved: (ID, ID) -> Unit,
     onSnackbarEvent: (TempoSnackbarEvent) -> Unit
 ) {
     val snackbarHostState = rememberSnackbarHostState()
@@ -71,8 +71,8 @@ internal fun RoutinesScene(
                     as? RoutinesItem.RoutineItem
             val hoveredSegment = routinesItems[itemMoved.indexHoveredItem]
                     as? RoutinesItem.RoutineItem
-            if (draggedSegment != null) {
-                onRoutineMoved(draggedSegment.id, hoveredSegment?.id)
+            if (draggedSegment != null && hoveredSegment != null) {
+                onRoutineMoved(draggedSegment.id, hoveredSegment.id)
             }
         }
     }
@@ -126,7 +126,7 @@ internal fun RoutinesScene(
                                                     if (draggableState.isDragging) animate.value else offsetY
                                             },
                                         enableClick = !draggableState.isDragging,
-                                        routine = item,
+                                        routineItem = item,
                                         onClick = onRoutine,
                                         onDelete = onRoutineDelete
                                     )
@@ -136,7 +136,7 @@ internal fun RoutinesScene(
                                             .fillMaxWidth()
                                             .alpha(0f),
                                         enableClick = false,
-                                        routine = item,
+                                        routineItem = item,
                                         onClick = { },
                                         onDelete = { }
                                     )

--- a/features/routines/src/main/java/com/enricog/features/routines/list/ui_components/RoutinesScene.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/list/ui_components/RoutinesScene.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import com.enricog.core.compose.api.classes.ImmutableList
+import com.enricog.core.compose.api.extensions.stringResourceOrNull
 import com.enricog.core.compose.api.modifiers.draggable.rememberListDraggableState
 import com.enricog.entities.ID
 import com.enricog.features.routines.R
@@ -42,7 +43,7 @@ internal fun RoutinesScene(
     val snackbarHostState = rememberSnackbarHostState()
     if (message != null) {
         val messageText = stringResource(id = message.textResId)
-        val actionText = stringResource(id = message.actionTextResId)
+        val actionText = stringResourceOrNull(id = message.actionTextResId)
         LaunchedEffect(snackbarHostState) {
             val event = snackbarHostState.show(message = messageText, actionText = actionText)
             onSnackbarEvent(event)

--- a/features/routines/src/main/java/com/enricog/features/routines/list/usecase/MoveRoutineUseCase.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/list/usecase/MoveRoutineUseCase.kt
@@ -1,0 +1,29 @@
+package com.enricog.features.routines.list.usecase
+
+import com.enricog.data.routines.api.RoutineDataSource
+import com.enricog.data.routines.api.entities.Routine
+import com.enricog.entities.ID
+import com.enricog.entities.Rank
+import javax.inject.Inject
+
+internal class MoveRoutineUseCase @Inject constructor(
+    private val routineDataSource: RoutineDataSource
+) {
+
+    suspend operator fun invoke(routines: List<Routine>, draggedRoutineId: ID, hoveredRoutineId: ID?) {
+        val currentIndex = routines.indexOfFirst { it.id == draggedRoutineId }
+        val newIndex = routines.indexOfFirst { it.id == hoveredRoutineId }
+
+        if (currentIndex == newIndex || currentIndex < 0) {
+            return
+        }
+
+        val rankTop = routines.getOrNull(newIndex)?.rank
+        val rankBottom = routines.getOrNull(newIndex + 1)?.rank
+        val newRank = Rank.Companion.calculate(rankTop = rankTop, rankBottom = rankBottom)
+        val routine = routines
+            .first { it.id == draggedRoutineId }
+            .copy(rank = newRank)
+        routineDataSource.update(routine)
+    }
+}

--- a/features/routines/src/main/java/com/enricog/features/routines/list/usecase/MoveRoutineUseCase.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/list/usecase/MoveRoutineUseCase.kt
@@ -13,12 +13,14 @@ internal class MoveRoutineUseCase @Inject constructor(
     suspend operator fun invoke(
         routines: List<Routine>,
         draggedRoutineId: ID,
-        hoveredRoutineId: ID?
+        hoveredRoutineId: ID
     ) {
         val currentIndex = routines.indexOfFirst { it.id == draggedRoutineId }
+            .takeIf { it >= 0 } ?: return
         val newIndex = routines.indexOfFirst { it.id == hoveredRoutineId }
+            .takeIf { it >= 0 } ?: return
 
-        if (currentIndex == newIndex || currentIndex < 0) {
+        if (currentIndex == newIndex) {
             return
         }
 

--- a/features/routines/src/main/java/com/enricog/features/routines/list/usecase/MoveRoutineUseCase.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/list/usecase/MoveRoutineUseCase.kt
@@ -10,7 +10,11 @@ internal class MoveRoutineUseCase @Inject constructor(
     private val routineDataSource: RoutineDataSource
 ) {
 
-    suspend operator fun invoke(routines: List<Routine>, draggedRoutineId: ID, hoveredRoutineId: ID?) {
+    suspend operator fun invoke(
+        routines: List<Routine>,
+        draggedRoutineId: ID,
+        hoveredRoutineId: ID?
+    ) {
         val currentIndex = routines.indexOfFirst { it.id == draggedRoutineId }
         val newIndex = routines.indexOfFirst { it.id == hoveredRoutineId }
 
@@ -18,9 +22,14 @@ internal class MoveRoutineUseCase @Inject constructor(
             return
         }
 
-        val rankTop = routines.getOrNull(newIndex)?.rank
-        val rankBottom = routines.getOrNull(newIndex + 1)?.rank
-        val newRank = Rank.Companion.calculate(rankTop = rankTop, rankBottom = rankBottom)
+        fun getRank(index: Int): Rank? = routines.getOrNull(index)?.rank
+
+        val (rankTop, rankBottom) = if (currentIndex > newIndex) {
+            getRank(index = newIndex - 1) to getRank(index = newIndex)
+        } else {
+            getRank(index = newIndex) to getRank(index = newIndex + 1)
+        }
+        val newRank = Rank.calculate(rankTop = rankTop, rankBottom = rankBottom)
         val routine = routines
             .first { it.id == draggedRoutineId }
             .copy(rank = newRank)

--- a/features/routines/src/main/res/values/strings.xml
+++ b/features/routines/src/main/res/values/strings.xml
@@ -9,6 +9,7 @@
     <string name="content_description_button_create_routine">Create a new routine</string>
     <string name="label_routines_delete_error">An error happen</string>
     <string name="action_text_routines_delete_error">Retry</string>
+    <string name="label_routines_move_error">An error happen</string>
 
     <!-- Routine -->
     <string name="field_label_routine_name">Routine name</string>

--- a/features/routines/src/test/java/com/enricog/features/routines/detail/summary/RoutineSummaryReducerTest.kt
+++ b/features/routines/src/test/java/com/enricog/features/routines/detail/summary/RoutineSummaryReducerTest.kt
@@ -106,7 +106,7 @@ class RoutineSummaryReducerTest {
             action = Action.MoveSegmentError
         )
 
-        val result = sut.segmentMoveError(state = state)
+        val result = sut.moveSegmentError(state = state)
 
         assertEquals(expected, result)
     }

--- a/features/routines/src/test/java/com/enricog/features/routines/detail/summary/RoutineSummaryViewModelTest.kt
+++ b/features/routines/src/test/java/com/enricog/features/routines/detail/summary/RoutineSummaryViewModelTest.kt
@@ -252,7 +252,7 @@ class RoutineSummaryViewModelTest {
         val sut = buildSut()
         advanceUntilIdle()
 
-        sut.onSegmentMoved(draggedSegmentId = 2.asID, hoveredSegmentId = null)
+        sut.onSegmentMoved(draggedSegmentId = 2.asID, hoveredSegmentId = 1.asID)
         advanceUntilIdle()
 
         sut.viewState.test { assertEquals(expected, awaitItem()) }
@@ -278,7 +278,7 @@ class RoutineSummaryViewModelTest {
         advanceUntilIdle()
 
         store.enableErrorOnNextAccess()
-        sut.onSegmentMoved(draggedSegmentId = 2.asID, hoveredSegmentId = null)
+        sut.onSegmentMoved(draggedSegmentId = 2.asID, hoveredSegmentId = 1.asID)
         advanceUntilIdle()
 
         sut.viewState.test { assertEquals(expected, awaitItem()) }
@@ -300,7 +300,7 @@ class RoutineSummaryViewModelTest {
         val sut = buildSut(store = store)
         advanceUntilIdle()
         store.enableErrorOnNextAccess()
-        sut.onSegmentMoved(draggedSegmentId = 2.asID, hoveredSegmentId = null)
+        sut.onSegmentMoved(draggedSegmentId = 2.asID, hoveredSegmentId = 1.asID)
         advanceUntilIdle()
 
         sut.onSnackbarEvent(snackbarEvent = TempoSnackbarEvent.ActionPerformed)

--- a/features/routines/src/test/java/com/enricog/features/routines/detail/summary/usecase/MoveSegmentUseCaseTest.kt
+++ b/features/routines/src/test/java/com/enricog/features/routines/detail/summary/usecase/MoveSegmentUseCaseTest.kt
@@ -18,58 +18,103 @@ class MoveSegmentUseCaseTest {
     @get:Rule
     val coroutineRule = CoroutineRule()
 
-    private val segment1 = Segment.EMPTY.copy(id = ID.from(1), rank = Rank.from("bbbbbb"))
-    private val segment2 = Segment.EMPTY.copy(id = ID.from(2), rank = Rank.from("cccccc"))
-    private val segment3 = Segment.EMPTY.copy(id = ID.from(3), rank = Rank.from("dddddd"))
-    private val routine =
-        Routine.EMPTY.copy(id = ID.from(1), segments = listOf(segment1, segment2, segment3))
+    private val segment1 =
+        Segment.EMPTY.copy(id = ID.from(value = 1), rank = Rank.from(value = "bbbbbb"))
+    private val segment2 =
+        Segment.EMPTY.copy(id = ID.from(value = 2), rank = Rank.from(value = "cccccc"))
+    private val segment3 =
+        Segment.EMPTY.copy(id = ID.from(value = 3), rank = Rank.from(value = "dddddd"))
+    private val routine = Routine.EMPTY.copy(
+        id = ID.from(value = 1),
+        segments = listOf(segment1, segment2, segment3)
+    )
 
     private val store = FakeStore(listOf(routine))
-    private val sut = MoveSegmentUseCase(routineDataSource = FakeRoutineDataSource(store))
-
+    private val routineDataSource = FakeRoutineDataSource(store)
+    private val sut = MoveSegmentUseCase(routineDataSource = routineDataSource)
 
     @Test
-    fun `should do nothing when item has not been moved`() = coroutineRule {
-        sut(routine = routine, draggedSegmentId = 1.asID, hoveredSegmentId = 1.asID)
+    fun `should do nothing when segment has not been moved`() = coroutineRule {
+        sut(routine = routine, draggedSegmentId = segment1.id, hoveredSegmentId = segment1.id)
 
-        assertEquals(routine, store.get().first())
+        assertEquals(routine, getActual())
     }
 
     @Test
-    fun `should do nothing when moved segment is not found`() = coroutineRule {
+    fun `should do nothing when dragged segment is not found`() = coroutineRule {
         val segmentIdUnknown = 4.asID
-        sut(routine = routine, draggedSegmentId = segmentIdUnknown, hoveredSegmentId = 1.asID)
+        sut(routine = routine, draggedSegmentId = segmentIdUnknown, hoveredSegmentId = segment1.id)
 
-        assertEquals(routine, store.get().first())
+        assertEquals(routine, getActual())
     }
 
     @Test
-    fun `should move segment`() = coroutineRule {
-        val expected = routine.copy(
-            segments = listOf(
-                segment1.copy(rank = Rank.from("oooooo")),
-                segment2,
-                segment3,
-            )
-        )
+    fun `should do nothing when hovered segment is not found`() = coroutineRule {
+        val segmentIdUnknown = 4.asID
+        sut(routine = routine, draggedSegmentId = segment1.id, hoveredSegmentId = segmentIdUnknown)
 
-        sut(routine = routine, draggedSegmentId = 1.asID, hoveredSegmentId = 3.asID)
-
-        assertEquals(expected, store.get().first())
+        assertEquals(routine, getActual())
     }
 
     @Test
-    fun `should move segment to the top when hovered segment is null`() = coroutineRule {
+    fun `should move segment up replacing the hovered segment`() = coroutineRule {
         val expected = routine.copy(
             segments = listOf(
                 segment1,
-                segment2,
-                segment3.copy(rank = Rank.from("annnnn"))
+                segment3.copy(rank = Rank.from(value = "booooo")),
+                segment2
             )
         )
 
-        sut(routine = routine, draggedSegmentId = 3.asID, hoveredSegmentId = null)
+        sut(routine = routine, draggedSegmentId = segment3.id, hoveredSegmentId = segment2.id)
 
-        assertEquals(expected, store.get().first())
+        assertEquals(expected, getActual())
     }
+
+    @Test
+    fun `should move segment down replacing the hovered segment`() = coroutineRule {
+        val expected = routine.copy(
+            segments = listOf(
+                segment2,
+                segment1.copy(rank = Rank.from(value = "cppppp")),
+                segment3
+            )
+        )
+
+        sut(routine = routine, draggedSegmentId = segment1.id, hoveredSegmentId = segment2.id)
+
+        assertEquals(expected, getActual())
+    }
+
+    @Test
+    fun `should move segment to the top when hovered first segment`() = coroutineRule {
+        val expected = routine.copy(
+            segments = listOf(
+                segment3.copy(rank = Rank.from(value = "annnnn")),
+                segment1,
+                segment2
+            )
+        )
+
+        sut(routine = routine, draggedSegmentId = segment3.id, hoveredSegmentId = segment1.id)
+
+        assertEquals(expected, getActual())
+    }
+
+    @Test
+    fun `should move segment to the bottom when hovered last segment`() = coroutineRule {
+        val expected = routine.copy(
+            segments = listOf(
+                segment2,
+                segment3,
+                segment1.copy(rank = Rank.from(value = "oooooo"))
+            )
+        )
+
+        sut(routine = routine, draggedSegmentId = segment1.id, hoveredSegmentId = segment3.id)
+
+        assertEquals(expected, getActual())
+    }
+
+    private suspend fun getActual(): Routine = routineDataSource.get(routine.id)
 }

--- a/features/routines/src/test/java/com/enricog/features/routines/list/RoutinesReducerTest.kt
+++ b/features/routines/src/test/java/com/enricog/features/routines/list/RoutinesReducerTest.kt
@@ -5,6 +5,7 @@ import com.enricog.data.routines.testing.entities.EMPTY
 import com.enricog.entities.asID
 import com.enricog.features.routines.list.models.RoutinesState
 import com.enricog.features.routines.list.models.RoutinesState.Data.Action.DeleteRoutineError
+import com.enricog.features.routines.list.models.RoutinesState.Data.Action.MoveRoutineError
 import org.junit.Test
 import kotlin.test.assertEquals
 
@@ -43,7 +44,7 @@ class RoutinesReducerTest {
     }
 
     @Test
-    fun `should set state with delete routine error action`() {
+    fun `should apply delete routine error action`() {
         val routineId = 1.asID
         val routine = Routine.EMPTY.copy(id = routineId)
         val routines = listOf(routine)
@@ -54,6 +55,22 @@ class RoutinesReducerTest {
         )
 
         val result = sut.deleteRoutineError(state = state, routineId = routineId)
+
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `should apply move segment error action`() {
+        val routineId = 1.asID
+        val routine = Routine.EMPTY.copy(id = routineId)
+        val routines = listOf(routine)
+        val state = RoutinesState.Data(routines = routines, action = null)
+        val expected = RoutinesState.Data(
+            routines = routines,
+            action = MoveRoutineError
+        )
+
+        val result = sut.moveRoutineError(state = state)
 
         assertEquals(expected, result)
     }

--- a/features/routines/src/test/java/com/enricog/features/routines/list/RoutinesStateConverterTest.kt
+++ b/features/routines/src/test/java/com/enricog/features/routines/list/RoutinesStateConverterTest.kt
@@ -1,11 +1,11 @@
 package com.enricog.features.routines.list
 
-import com.enricog.core.compose.api.classes.emptyImmutableList
 import com.enricog.core.compose.api.classes.immutableListOf
 import com.enricog.core.coroutines.testing.CoroutineRule
 import com.enricog.data.routines.testing.entities.EMPTY
 import com.enricog.entities.asID
 import com.enricog.features.routines.R
+import com.enricog.features.routines.list.models.RoutinesItem
 import com.enricog.features.routines.list.models.RoutinesState
 import com.enricog.features.routines.list.models.RoutinesState.Data.Action
 import com.enricog.features.routines.list.models.RoutinesViewState
@@ -43,9 +43,14 @@ class RoutinesStateConverterTest {
     }
 
     @Test
-    fun `test map data with no action`() = coroutineRule {
-        val state = RoutinesState.Data(routines = emptyList(), action = null)
-        val viewState = RoutinesViewState.Data(routinesItems = emptyImmutableList(), message = null)
+    fun `test map data`() = coroutineRule {
+        val routineEntity = RoutineEntity.EMPTY
+        val routineItem = RoutinesItem.RoutineItem(id = 0.asID, name = "", rank = "aaaaaa")
+        val state = RoutinesState.Data(routines = listOf(routineEntity), action = null)
+        val viewState = RoutinesViewState.Data(
+            routinesItems = immutableListOf(routineItem, RoutinesItem.Space),
+            message = null
+        )
 
         val result = sut.convert(state)
 
@@ -55,16 +60,37 @@ class RoutinesStateConverterTest {
     @Test
     fun `test map data with delete routine error action`() = coroutineRule {
         val routineEntity = RoutineEntity.EMPTY
-        val routine = RoutinesViewState.Data.RoutineItem(id = 0.asID, name = "")
+        val routineItem = RoutinesItem.RoutineItem(id = 0.asID, name = "", rank = "aaaaaa")
         val state = RoutinesState.Data(
             routines = listOf(routineEntity),
             action = Action.DeleteRoutineError(routineEntity.id)
         )
         val viewState = RoutinesViewState.Data(
-            routinesItems = immutableListOf(routine),
+            routinesItems = immutableListOf(routineItem, RoutinesItem.Space),
             message = Message(
                 textResId = R.string.label_routines_delete_error,
                 actionTextResId = R.string.action_text_routines_delete_error
+            )
+        )
+
+        val result = sut.convert(state)
+
+        assertEquals(viewState, result)
+    }
+
+    @Test
+    fun `test map data with move routine error action`() = coroutineRule {
+        val routineEntity = RoutineEntity.EMPTY
+        val routineItem = RoutinesItem.RoutineItem(id = 0.asID, name = "", rank = "aaaaaa")
+        val state = RoutinesState.Data(
+            routines = listOf(routineEntity),
+            action = Action.MoveRoutineError
+        )
+        val viewState = RoutinesViewState.Data(
+            routinesItems = immutableListOf(routineItem, RoutinesItem.Space),
+            message = Message(
+                textResId = R.string.label_routines_move_error,
+                actionTextResId = null
             )
         )
 

--- a/features/routines/src/test/java/com/enricog/features/routines/list/RoutinesStateConverterTest.kt
+++ b/features/routines/src/test/java/com/enricog/features/routines/list/RoutinesStateConverterTest.kt
@@ -45,7 +45,7 @@ class RoutinesStateConverterTest {
     @Test
     fun `test map data with no action`() = coroutineRule {
         val state = RoutinesState.Data(routines = emptyList(), action = null)
-        val viewState = RoutinesViewState.Data(routines = emptyImmutableList(), message = null)
+        val viewState = RoutinesViewState.Data(routinesItems = emptyImmutableList(), message = null)
 
         val result = sut.convert(state)
 
@@ -55,13 +55,13 @@ class RoutinesStateConverterTest {
     @Test
     fun `test map data with delete routine error action`() = coroutineRule {
         val routineEntity = RoutineEntity.EMPTY
-        val routine = RoutinesViewState.Data.Routine(id = 0.asID, name = "")
+        val routine = RoutinesViewState.Data.RoutineItem(id = 0.asID, name = "")
         val state = RoutinesState.Data(
             routines = listOf(routineEntity),
             action = Action.DeleteRoutineError(routineEntity.id)
         )
         val viewState = RoutinesViewState.Data(
-            routines = immutableListOf(routine),
+            routinesItems = immutableListOf(routine),
             message = Message(
                 textResId = R.string.label_routines_delete_error,
                 actionTextResId = R.string.action_text_routines_delete_error

--- a/features/routines/src/test/java/com/enricog/features/routines/list/RoutinesViewModelTest.kt
+++ b/features/routines/src/test/java/com/enricog/features/routines/list/RoutinesViewModelTest.kt
@@ -7,10 +7,12 @@ import com.enricog.data.local.testing.FakeStore
 import com.enricog.data.routines.testing.FakeRoutineDataSource
 import com.enricog.data.routines.testing.entities.EMPTY
 import com.enricog.entities.ID
+import com.enricog.entities.Rank
 import com.enricog.entities.asID
 import com.enricog.features.routines.R
+import com.enricog.features.routines.list.models.RoutinesItem
 import com.enricog.features.routines.list.models.RoutinesViewState
-import com.enricog.features.routines.list.models.RoutinesViewState.Data.RoutineItem
+import com.enricog.features.routines.list.usecase.MoveRoutineUseCase
 import com.enricog.features.routines.list.usecase.RoutinesUseCase
 import com.enricog.features.routines.navigation.RoutinesNavigationActions
 import com.enricog.navigation.api.routes.RoutineRoute
@@ -35,26 +37,31 @@ class RoutinesViewModelTest {
     private val firstRoutineEntity = RoutineEntity.EMPTY.copy(
         id = 1.asID,
         name = "First Routine",
+        rank = Rank.from(value = "aaaaaa")
     )
     private val secondRoutineEntity = RoutineEntity.EMPTY.copy(
         id = 2.asID,
         name = "Second Routine",
+        rank = Rank.from(value = "bbbbbb")
     )
-    private val firstRoutine = RoutineItem(
+    private val firstRoutine = RoutinesItem.RoutineItem(
         id = 1.asID,
         name = "First Routine",
+        rank = "aaaaaa"
     )
-    private val secondRoutine = RoutineItem(
+    private val secondRoutine = RoutinesItem.RoutineItem(
         id = 2.asID,
         name = "Second Routine",
+        rank = "bbbbbb"
     )
     private val navigator = FakeNavigator()
     private val store = FakeStore(listOf(firstRoutineEntity, secondRoutineEntity))
+    private val routineDataSource = FakeRoutineDataSource(store = store)
 
     @Test
     fun `should should show data when load succeeds`() = coroutineRule {
         val expected = RoutinesViewState.Data(
-            routinesItems = immutableListOf(firstRoutine, secondRoutine),
+            routinesItems = immutableListOf(firstRoutine, secondRoutine, RoutinesItem.Space),
             message = null
         )
         val sut = buildSut()
@@ -100,7 +107,10 @@ class RoutinesViewModelTest {
 
     @Test
     fun `should remove routine when delete routine clicked`() = coroutineRule {
-        val expected = RoutinesViewState.Data(routinesItems = immutableListOf(secondRoutine), message = null)
+        val expected = RoutinesViewState.Data(
+            routinesItems = immutableListOf(secondRoutine, RoutinesItem.Space),
+            message = null
+        )
         val sut = buildSut()
         advanceUntilIdle()
 
@@ -113,7 +123,7 @@ class RoutinesViewModelTest {
     @Test
     fun `should show message when delete routine clicked and deletion fails`() = coroutineRule {
         val expected = RoutinesViewState.Data(
-            routinesItems = immutableListOf(firstRoutine, secondRoutine),
+            routinesItems = immutableListOf(firstRoutine, secondRoutine, RoutinesItem.Space),
             message = RoutinesViewState.Data.Message(
                 textResId = R.string.label_routines_delete_error,
                 actionTextResId = R.string.action_text_routines_delete_error
@@ -132,7 +142,7 @@ class RoutinesViewModelTest {
     @Test
     fun `should hide message when when snackbar is dismissed`() = coroutineRule {
         val expected = RoutinesViewState.Data(
-            routinesItems = immutableListOf(firstRoutine, secondRoutine),
+            routinesItems = immutableListOf(firstRoutine, secondRoutine, RoutinesItem.Space),
             message = null
         )
         val sut = buildSut()
@@ -150,7 +160,7 @@ class RoutinesViewModelTest {
     @Test
     fun `should retry delete when when snackbar action is clicked`() = coroutineRule {
         val expected = RoutinesViewState.Data(
-            routinesItems = immutableListOf(secondRoutine),
+            routinesItems = immutableListOf(secondRoutine, RoutinesItem.Space),
             message = null
         )
         val sut = buildSut()
@@ -168,7 +178,7 @@ class RoutinesViewModelTest {
     @Test
     fun `should reload when retry button clicked`() = coroutineRule {
         val expected = RoutinesViewState.Data(
-            routinesItems = immutableListOf(secondRoutine),
+            routinesItems = immutableListOf(secondRoutine, RoutinesItem.Space),
             message = null
         )
         val sut = buildSut()
@@ -186,7 +196,10 @@ class RoutinesViewModelTest {
             navigationActions = RoutinesNavigationActions(navigator),
             reducer = RoutinesReducer(),
             routinesUseCase = RoutinesUseCase(
-                routineDataSource = FakeRoutineDataSource(store = store)
+                routineDataSource = routineDataSource
+            ),
+            moveRoutineUseCase = MoveRoutineUseCase(
+                routineDataSource = routineDataSource
             )
         )
     }

--- a/features/routines/src/test/java/com/enricog/features/routines/list/RoutinesViewModelTest.kt
+++ b/features/routines/src/test/java/com/enricog/features/routines/list/RoutinesViewModelTest.kt
@@ -10,7 +10,7 @@ import com.enricog.entities.ID
 import com.enricog.entities.asID
 import com.enricog.features.routines.R
 import com.enricog.features.routines.list.models.RoutinesViewState
-import com.enricog.features.routines.list.models.RoutinesViewState.Data.Routine
+import com.enricog.features.routines.list.models.RoutinesViewState.Data.RoutineItem
 import com.enricog.features.routines.list.usecase.RoutinesUseCase
 import com.enricog.features.routines.navigation.RoutinesNavigationActions
 import com.enricog.navigation.api.routes.RoutineRoute
@@ -40,11 +40,11 @@ class RoutinesViewModelTest {
         id = 2.asID,
         name = "Second Routine",
     )
-    private val firstRoutine = Routine(
+    private val firstRoutine = RoutineItem(
         id = 1.asID,
         name = "First Routine",
     )
-    private val secondRoutine = Routine(
+    private val secondRoutine = RoutineItem(
         id = 2.asID,
         name = "Second Routine",
     )
@@ -54,7 +54,7 @@ class RoutinesViewModelTest {
     @Test
     fun `should should show data when load succeeds`() = coroutineRule {
         val expected = RoutinesViewState.Data(
-            routines = immutableListOf(firstRoutine, secondRoutine),
+            routinesItems = immutableListOf(firstRoutine, secondRoutine),
             message = null
         )
         val sut = buildSut()
@@ -100,7 +100,7 @@ class RoutinesViewModelTest {
 
     @Test
     fun `should remove routine when delete routine clicked`() = coroutineRule {
-        val expected = RoutinesViewState.Data(routines = immutableListOf(secondRoutine), message = null)
+        val expected = RoutinesViewState.Data(routinesItems = immutableListOf(secondRoutine), message = null)
         val sut = buildSut()
         advanceUntilIdle()
 
@@ -113,7 +113,7 @@ class RoutinesViewModelTest {
     @Test
     fun `should show message when delete routine clicked and deletion fails`() = coroutineRule {
         val expected = RoutinesViewState.Data(
-            routines = immutableListOf(firstRoutine, secondRoutine),
+            routinesItems = immutableListOf(firstRoutine, secondRoutine),
             message = RoutinesViewState.Data.Message(
                 textResId = R.string.label_routines_delete_error,
                 actionTextResId = R.string.action_text_routines_delete_error
@@ -132,7 +132,7 @@ class RoutinesViewModelTest {
     @Test
     fun `should hide message when when snackbar is dismissed`() = coroutineRule {
         val expected = RoutinesViewState.Data(
-            routines = immutableListOf(firstRoutine, secondRoutine),
+            routinesItems = immutableListOf(firstRoutine, secondRoutine),
             message = null
         )
         val sut = buildSut()
@@ -150,7 +150,7 @@ class RoutinesViewModelTest {
     @Test
     fun `should retry delete when when snackbar action is clicked`() = coroutineRule {
         val expected = RoutinesViewState.Data(
-            routines = immutableListOf(secondRoutine),
+            routinesItems = immutableListOf(secondRoutine),
             message = null
         )
         val sut = buildSut()
@@ -168,7 +168,7 @@ class RoutinesViewModelTest {
     @Test
     fun `should reload when retry button clicked`() = coroutineRule {
         val expected = RoutinesViewState.Data(
-            routines = immutableListOf(secondRoutine),
+            routinesItems = immutableListOf(secondRoutine),
             message = null
         )
         val sut = buildSut()

--- a/features/routines/src/test/java/com/enricog/features/routines/list/usecase/MoveRoutineUseCaseTest.kt
+++ b/features/routines/src/test/java/com/enricog/features/routines/list/usecase/MoveRoutineUseCaseTest.kt
@@ -1,0 +1,117 @@
+package com.enricog.features.routines.list.usecase
+
+import com.enricog.core.coroutines.testing.CoroutineRule
+import com.enricog.data.local.testing.FakeStore
+import com.enricog.data.routines.api.entities.Routine
+import com.enricog.data.routines.testing.FakeRoutineDataSource
+import com.enricog.data.routines.testing.entities.EMPTY
+import com.enricog.entities.ID
+import com.enricog.entities.Rank
+import com.enricog.entities.asID
+import org.junit.Rule
+import org.junit.Test
+import kotlin.test.assertEquals
+
+internal class MoveRoutineUseCaseTest {
+
+    @get:Rule
+    val coroutineRule = CoroutineRule()
+
+    private val routine1 =
+        Routine.EMPTY.copy(id = ID.from(value = 1), rank = Rank.from(value = "bbbbbb"))
+    private val routine2 =
+        Routine.EMPTY.copy(id = ID.from(value = 2), rank = Rank.from(value = "cccccc"))
+    private val routine3 =
+        Routine.EMPTY.copy(id = ID.from(value = 3), rank = Rank.from(value = "dddddd"))
+    private val routines = listOf(routine1, routine2, routine3)
+
+    private val store = FakeStore(routines)
+    private val routineDataSource = FakeRoutineDataSource(store)
+    private val sut = MoveRoutineUseCase(routineDataSource = routineDataSource)
+
+    @Test
+    fun `should do nothing when routine has not been moved`() = coroutineRule {
+        sut(routines = routines, draggedRoutineId = routine1.id, hoveredRoutineId = routine1.id)
+
+        assertEquals(routines, getActual())
+    }
+
+    @Test
+    fun `should do nothing when dragged routine is not found`() = coroutineRule {
+        val routineIdUnknown = 4.asID
+
+        sut(
+            routines = routines,
+            draggedRoutineId = routineIdUnknown,
+            hoveredRoutineId = routine1.id
+        )
+
+        assertEquals(routines, getActual())
+    }
+
+    @Test
+    fun `should do nothing when hovered routine is not found`() = coroutineRule {
+        val routineIdUnknown = 4.asID
+        sut(
+            routines = routines,
+            draggedRoutineId = routine1.id,
+            hoveredRoutineId = routineIdUnknown
+        )
+
+        assertEquals(routines, getActual())
+    }
+
+    @Test
+    fun `should move routine up replacing the hovered routine`() = coroutineRule {
+        val expected = listOf(
+            routine1,
+            routine3.copy(rank = Rank.from(value = "booooo")),
+            routine2
+        )
+
+        sut(routines = routines, draggedRoutineId = routine3.id, hoveredRoutineId = routine2.id)
+
+        assertEquals(expected, getActual())
+    }
+
+    @Test
+    fun `should move routine down replacing the hovered routine`() = coroutineRule {
+        val expected = listOf(
+            routine2,
+            routine1.copy(rank = Rank.from(value = "cppppp")),
+            routine3
+        )
+
+        sut(routines = routines, draggedRoutineId = routine1.id, hoveredRoutineId = routine2.id)
+
+        assertEquals(expected, getActual())
+    }
+
+    @Test
+    fun `should move routine to the top when hovered first routine`() = coroutineRule {
+        val expected = listOf(
+            routine3.copy(rank = Rank.from(value = "annnnn")),
+            routine1,
+            routine2
+        )
+
+        sut(routines = routines, draggedRoutineId = routine3.id, hoveredRoutineId = routine1.id)
+
+        assertEquals(expected, getActual())
+    }
+
+    @Test
+    fun `should move routine to the bottom when hovered last routine`() = coroutineRule {
+        val expected = listOf(
+            routine2,
+            routine3,
+            routine1.copy(rank = Rank.from(value = "oooooo"))
+        )
+
+        sut(routines = routines, draggedRoutineId = routine1.id, hoveredRoutineId = routine3.id)
+
+        assertEquals(expected, getActual())
+    }
+
+    private suspend fun getActual(): List<Routine> = routineDataSource.getAll()
+}


### PR DESCRIPTION
Routines now can be ordered.

## Major Changes

### Add new field `rank` to `Routine` class
By adding this new field it was required to update the database version to `2`
A database migration has been created in order to handle the migration to the new version of the database. The migration is adding a new column to the `Routines` table and the rank is being generated keeping the routine order previously used (creation date descending)

### `RoutinesScene`
Made some UI changes in the routine's list composable: while dragging the floating action button to add a new routine disappears from the screen and at the bottom of the list has been added a space to avoid that the routines, at the bottom of the screen, are partially covered by the floating action button.

### Fix `MoveXXXUseCase`
Currently, this kind of use case is implemented based on a bug in the UI related to the hovered item in a list. The implementation has been updated to correctly detect the ranks to be used in order to place the dragged item.
