### PR TITLE
Feature: Show segments summary in the routine list

### DIFF
--- a/.idea/androidTestResultsUserPreferences.xml
+++ b/.idea/androidTestResultsUserPreferences.xml
@@ -84,6 +84,20 @@
             </AndroidTestResultsTableState>
           </value>
         </entry>
+        <entry key="-552392428">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="19291FDF6002X0" value="120" />
+                  <entry key="Duration" value="90" />
+                  <entry key="Google&#10; Pixel 6" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
         <entry key="-339337853">
           <value>
             <AndroidTestResultsTableState>
@@ -134,6 +148,19 @@
                   <entry key="19291FDF6002X0" value="120" />
                   <entry key="Duration" value="90" />
                   <entry key="Google&#10; Pixel 6" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
+        <entry key="981041092">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="19291FDF6002X0" value="120" />
+                  <entry key="Duration" value="90" />
                   <entry key="Tests" value="360" />
                 </map>
               </option>

--- a/core/compose/api/src/main/java/com/enricog/core/compose/api/modifiers/spacing/ListItemSpacingModifier.kt
+++ b/core/compose/api/src/main/java/com/enricog/core/compose/api/modifiers/spacing/ListItemSpacingModifier.kt
@@ -7,7 +7,8 @@ import androidx.compose.ui.unit.dp
 
 fun Modifier.verticalListItemSpacing(
     itemPosition: Int,
-    spacing: Dp,
+    spacingVertical: Dp,
+    spacingHorizontal: Dp,
     includeEdge: Boolean = true
 ): Modifier {
     var top = 0.dp
@@ -15,18 +16,18 @@ fun Modifier.verticalListItemSpacing(
 
     if (includeEdge) {
         if (itemPosition == 0) {
-            top = spacing
+            top = spacingVertical
         }
-        bottom = spacing
+        bottom = spacingVertical
     } else {
         if (itemPosition > 0) {
-            top = spacing
+            top = spacingVertical
         }
     }
 
     return padding(
-        start = spacing,
-        end = spacing,
+        start = spacingHorizontal,
+        end = spacingHorizontal,
         top = top,
         bottom = bottom
     )
@@ -34,7 +35,8 @@ fun Modifier.verticalListItemSpacing(
 
 fun Modifier.horizontalListItemSpacing(
     itemPosition: Int,
-    spacing: Dp,
+    spacingVertical: Dp,
+    spacingHorizontal: Dp,
     includeEdge: Boolean = true
 ): Modifier {
     var start = 0.dp
@@ -42,19 +44,19 @@ fun Modifier.horizontalListItemSpacing(
 
     if (includeEdge) {
         if (itemPosition == 0) {
-            start = spacing
+            start = spacingHorizontal
         }
-        end = spacing
+        end = spacingHorizontal
     } else {
         if (itemPosition > 0) {
-            start = spacing
+            start = spacingHorizontal
         }
     }
 
     return padding(
         start = start,
         end = end,
-        top = spacing,
-        bottom = spacing
+        top = spacingVertical,
+        bottom = spacingVertical
     )
 }

--- a/features/routines/src/androidTest/java/com/enricog/features/routines/list/RoutinesScreenKtTest.kt
+++ b/features/routines/src/androidTest/java/com/enricog/features/routines/list/RoutinesScreenKtTest.kt
@@ -3,8 +3,13 @@ package com.enricog.features.routines.list
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
-import com.enricog.core.compose.api.classes.emptyImmutableList
+import com.enricog.core.compose.api.classes.immutableListOf
+import com.enricog.core.compose.api.classes.immutableMapOf
 import com.enricog.core.compose.testing.invoke
+import com.enricog.entities.asID
+import com.enricog.entities.seconds
+import com.enricog.features.routines.detail.ui.time_type.TimeType
+import com.enricog.features.routines.list.models.RoutinesItem
 import com.enricog.features.routines.list.models.RoutinesViewState
 import com.enricog.features.routines.list.ui_components.RoutinesEmptySceneTestTag
 import com.enricog.features.routines.list.ui_components.RoutinesErrorSceneTestTag
@@ -12,6 +17,7 @@ import com.enricog.features.routines.list.ui_components.RoutinesSceneTestTag
 import com.enricog.ui.theme.TempoTheme
 import org.junit.Rule
 import org.junit.Test
+import com.enricog.data.routines.api.entities.TimeType as TimeTypeEntity
 
 class RoutinesScreenKtTest {
 
@@ -68,7 +74,25 @@ class RoutinesScreenKtTest {
 
     @Test
     fun shouldRenderRoutinesSceneWhenStateIsData() = composeRule {
-        val viewState = RoutinesViewState.Data(routinesItems = emptyImmutableList(), message = null)
+        val viewState = RoutinesViewState.Data(
+            routinesItems = immutableListOf(
+                RoutinesItem.RoutineItem(
+                    id = 0.asID,
+                    name = "Routine",
+                    rank = "aaaaaa",
+                    segmentsSummary = RoutinesItem.RoutineItem.SegmentsSummary(
+                        totalTime = 12.seconds,
+                        segmentTypesCount = immutableMapOf(
+                            TimeType.from(TimeTypeEntity.TIMER) to 2,
+                            TimeType.from(TimeTypeEntity.REST) to 1,
+                            TimeType.from(TimeTypeEntity.STOPWATCH) to 1
+                        )
+                    )
+                ),
+                RoutinesItem.Space
+            ),
+            message = null
+        )
 
         setContent {
             TempoTheme {

--- a/features/routines/src/androidTest/java/com/enricog/features/routines/list/ui_components/RoutineItemKtTest.kt
+++ b/features/routines/src/androidTest/java/com/enricog/features/routines/list/ui_components/RoutineItemKtTest.kt
@@ -1,0 +1,141 @@
+package com.enricog.features.routines.list.ui_components
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import com.enricog.core.compose.api.classes.immutableMapOf
+import com.enricog.core.compose.testing.invoke
+import com.enricog.entities.asID
+import com.enricog.entities.seconds
+import com.enricog.features.routines.detail.ui.time_type.TimeType
+import com.enricog.features.routines.list.models.RoutinesItem
+import com.enricog.ui.theme.TempoTheme
+import org.junit.Rule
+import org.junit.Test
+import com.enricog.data.routines.api.entities.TimeType as TimeTypeEntity
+
+class RoutineItemKtTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun shouldRenderRoutineItemWithSegmentSummary() = composeRule {
+        val routineItem = RoutinesItem.RoutineItem(
+            id = 0.asID,
+            name = "Routine",
+            rank = "aaaaaa",
+            segmentsSummary = RoutinesItem.RoutineItem.SegmentsSummary(
+                totalTime = 12.seconds,
+                segmentTypesCount = immutableMapOf(
+                    TimeType.from(TimeTypeEntity.TIMER) to 2,
+                    TimeType.from(TimeTypeEntity.REST) to 1,
+                    TimeType.from(TimeTypeEntity.STOPWATCH) to 1
+                )
+            )
+        )
+
+        setContent {
+            TempoTheme {
+                RoutineItem(
+                    routineItem = routineItem,
+                    enableClick = true,
+                    onClick = {},
+                    onDelete = {}
+                )
+            }
+        }
+
+        waitForIdle()
+
+        onNodeWithTag(testTag = RoutineItemTestTag).assertIsDisplayed()
+        onNodeWithText(text = routineItem.name).assertIsDisplayed()
+
+        onNodeWithTag(testTag = RoutineItemCountTestTag, useUnmergedTree = true).assertIsDisplayed()
+        onNodeWithTag(testTag = RoutineItemTotalTimeTestTag, useUnmergedTree = true)
+            .assertTextEquals("12s")
+        onNodeWithTag(testTag = "RoutineItemSegmentTypeCount_TIMER_TestTag", useUnmergedTree = true)
+            .assertTextEquals("2")
+        onNodeWithTag(testTag = "RoutineItemSegmentTypeCount_REST_TestTag", useUnmergedTree = true)
+            .assertTextEquals("1")
+        onNodeWithTag(testTag = "RoutineItemSegmentTypeCount_STOPWATCH_TestTag", useUnmergedTree = true)
+            .assertTextEquals("1")
+    }
+
+    @Test
+    fun shouldRenderRoutineItemWithoutCountWhenSummaryIsNull() = composeRule {
+        val routineItem = RoutinesItem.RoutineItem(
+            id = 0.asID,
+            name = "Routine",
+            rank = "aaaaaa",
+            segmentsSummary = null
+        )
+
+        setContent {
+            TempoTheme {
+                RoutineItem(
+                    routineItem = routineItem,
+                    enableClick = true,
+                    onClick = {},
+                    onDelete = {}
+                )
+            }
+        }
+
+        waitForIdle()
+
+        onNodeWithTag(testTag = RoutineItemTestTag).assertIsDisplayed()
+        onNodeWithText(text = routineItem.name).assertIsDisplayed()
+
+        onNodeWithTag(testTag = RoutineItemTotalTimeTestTag, useUnmergedTree = true).assertDoesNotExist()
+        onNodeWithTag(testTag = RoutineItemCountTestTag, useUnmergedTree = true).assertDoesNotExist()
+        onNodeWithTag(testTag = "RoutineItemSegmentTypeCount_TIMER_TestTag", useUnmergedTree = true)
+            .assertDoesNotExist()
+        onNodeWithTag(testTag = "RoutineItemSegmentTypeCount_REST_TestTag", useUnmergedTree = true)
+            .assertDoesNotExist()
+        onNodeWithTag(testTag = "RoutineItemSegmentTypeCount_STOPWATCH_TestTag", useUnmergedTree = true)
+            .assertDoesNotExist()
+    }
+
+    @Test
+    fun shouldRenderRoutineItemWithoutTotalTimeWhenIsNull() = composeRule {
+        val routineItem = RoutinesItem.RoutineItem(
+            id = 0.asID,
+            name = "Routine",
+            rank = "aaaaaa",
+            segmentsSummary = RoutinesItem.RoutineItem.SegmentsSummary(
+                totalTime = null,
+                segmentTypesCount = immutableMapOf(
+                    TimeType.from(TimeTypeEntity.STOPWATCH) to 1
+                )
+            )
+        )
+
+        setContent {
+            TempoTheme {
+                RoutineItem(
+                    routineItem = routineItem,
+                    enableClick = true,
+                    onClick = {},
+                    onDelete = {}
+                )
+            }
+        }
+
+        waitForIdle()
+
+        onNodeWithTag(testTag = RoutineItemTestTag).assertIsDisplayed()
+        onNodeWithText(text = routineItem.name).assertIsDisplayed()
+
+        onNodeWithTag(testTag = RoutineItemCountTestTag, useUnmergedTree = true).assertIsDisplayed()
+        onNodeWithTag(testTag = RoutineItemTotalTimeTestTag, useUnmergedTree = true).assertDoesNotExist()
+        onNodeWithTag(testTag = "RoutineItemSegmentTypeCount_TIMER_TestTag", useUnmergedTree = true)
+            .assertDoesNotExist()
+        onNodeWithTag(testTag = "RoutineItemSegmentTypeCount_REST_TestTag", useUnmergedTree = true)
+            .assertDoesNotExist()
+        onNodeWithTag(testTag = "RoutineItemSegmentTypeCount_STOPWATCH_TestTag", useUnmergedTree = true)
+            .assertTextEquals("1")
+    }
+}

--- a/features/routines/src/main/java/com/enricog/features/routines/detail/segment/ui_components/SegmentTypeTabs.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/detail/segment/ui_components/SegmentTypeTabs.kt
@@ -65,7 +65,7 @@ internal fun SegmentTypeTabs(
                     orientation = Orientation.Horizontal
                 )
         ) {
-            timeTypes.mapIndexed { index, timeType ->
+            timeTypes.forEachIndexed { index, timeType ->
                 SegmentTypeTab(
                     value = timeType,
                     onClick = {
@@ -77,7 +77,8 @@ internal fun SegmentTypeTabs(
                     modifier = Modifier
                         .horizontalListItemSpacing(
                             itemPosition = index,
-                            spacing = tabSpace,
+                            spacingHorizontal = tabSpace,
+                            spacingVertical = tabSpace,
                             includeEdge = false
                         )
                         .width(width = tabWidth)

--- a/features/routines/src/main/java/com/enricog/features/routines/list/models/RoutinesItem.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/list/models/RoutinesItem.kt
@@ -1,8 +1,13 @@
 package com.enricog.features.routines.list.models
 
 import androidx.compose.runtime.Stable
+import com.enricog.core.compose.api.classes.ImmutableMap
+import com.enricog.core.compose.api.classes.asImmutableMap
 import com.enricog.data.routines.api.entities.Routine
 import com.enricog.entities.ID
+import com.enricog.entities.Seconds
+import com.enricog.entities.seconds
+import com.enricog.features.routines.detail.ui.time_type.TimeType
 
 internal sealed class RoutinesItem {
 
@@ -11,20 +16,40 @@ internal sealed class RoutinesItem {
     data class RoutineItem(
         @Stable val id: ID,
         val name: String,
-        val rank: String
+        val rank: String,
+        val segmentsSummary: SegmentsSummary?
     ) : RoutinesItem() {
 
         override val isDraggable: Boolean = true
 
+        data class SegmentsSummary(
+            @Stable val totalTime: Seconds?,
+            val segmentTypesCount: ImmutableMap<TimeType, Int>
+        )
+
         companion object {
-            fun from(routine: Routine) = RoutineItem(
-                id = routine.id,
-                name = routine.name,
-                rank = routine.rank.toString()
-            )
+            fun from(routine: Routine): RoutineItem {
+                val segmentsSummary = if (routine.segments.isNotEmpty()) {
+                    SegmentsSummary(
+                        totalTime = routine.segments.map { it.time }
+                            .reduce { acc, time -> acc + time }
+                            .takeIf { it > 0.seconds },
+                        segmentTypesCount = routine.segments.groupBy { it.type }
+                            .map { (type, segments) -> TimeType.from(type) to segments.size }
+                            .toMap()
+                            .asImmutableMap()
+                    )
+                } else null
+
+                return RoutineItem(
+                    id = routine.id,
+                    name = routine.name,
+                    rank = routine.rank.toString(),
+                    segmentsSummary = segmentsSummary
+                )
+            }
         }
     }
-
 
     object Space : RoutinesItem() {
         override val isDraggable: Boolean = false

--- a/features/routines/src/main/java/com/enricog/features/routines/list/ui_components/RoutineItem.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/list/ui_components/RoutineItem.kt
@@ -1,38 +1,132 @@
 package com.enricog.features.routines.list.ui_components
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.constraintlayout.compose.ConstraintLayout
+import androidx.constraintlayout.compose.Dimension
+import com.enricog.core.compose.api.modifiers.spacing.horizontalListItemSpacing
 import com.enricog.entities.ID
 import com.enricog.features.routines.list.models.RoutinesItem.RoutineItem
 import com.enricog.features.routines.ui_components.DeletableListItem
+import com.enricog.ui.components.extensions.format
 import com.enricog.ui.components.text.TempoText
 import com.enricog.ui.theme.TempoTheme
 
 internal const val RoutineItemTestTag = "RoutineItemTestTag"
+internal const val RoutineItemCountTestTag = "RoutineItemCountTestTag"
+internal const val RoutineItemTotalTimeTestTag = "RoutineItemTotalTimeTestTag"
+internal const val RoutineItemSegmentTypeCountTestTag =
+    "RoutineItemSegmentTypeCount_{{TYPE}}_TestTag"
 
 @Composable
 internal fun RoutineItem(
-    modifier: Modifier = Modifier,
     routineItem: RoutineItem,
     enableClick: Boolean,
     onClick: (ID) -> Unit,
-    onDelete: (ID) -> Unit
+    onDelete: (ID) -> Unit,
+    modifier: Modifier = Modifier
 ) {
     DeletableListItem(
         modifier = modifier
             .testTag(RoutineItemTestTag),
         onDelete = { onDelete(routineItem.id) }
     ) {
-        Box(modifier = Modifier.clickable(enabled = enableClick) { onClick(routineItem.id) }) {
+        ConstraintLayout(
+            modifier = Modifier
+                .clickable(enabled = enableClick) { onClick(routineItem.id) }
+                .padding(TempoTheme.dimensions.spaceM)
+        ) {
+            val (routineName, count) = createRefs()
             TempoText(
-                modifier = Modifier.padding(TempoTheme.dimensions.spaceM),
+                modifier = Modifier
+                    .constrainAs(routineName) {
+                        top.linkTo(parent.top)
+                        start.linkTo(parent.start)
+                        if (routineItem.segmentsSummary != null) {
+                            end.linkTo(count.start)
+                        } else {
+                            end.linkTo(parent.end)
+                        }
+                        width = Dimension.fillToConstraints
+                    },
                 text = routineItem.name,
-                style = TempoTheme.typography.h2
+                style = TempoTheme.typography.h2,
             )
+            if (routineItem.segmentsSummary != null) {
+                Counts(
+                    modifier = Modifier
+                        .padding(start = TempoTheme.dimensions.spaceL)
+                        .constrainAs(count) {
+                            top.linkTo(parent.top)
+                            bottom.linkTo(parent.bottom)
+                            start.linkTo(routineName.end)
+                            end.linkTo(parent.end)
+                        },
+                    segmentsSummary = routineItem.segmentsSummary
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun Counts(
+    segmentsSummary: RoutineItem.SegmentsSummary,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.testTag(RoutineItemCountTestTag),
+        horizontalAlignment = Alignment.End
+    ) {
+        if (segmentsSummary.totalTime != null) {
+            TempoText(
+                modifier = Modifier.testTag(RoutineItemTotalTimeTestTag),
+                text = segmentsSummary.totalTime.format(),
+                style = TempoTheme.typography.h3,
+                textAlign = TextAlign.End
+            )
+        }
+        Row {
+            segmentsSummary.segmentTypesCount.onEachIndexed { index, (timeType, count) ->
+                Box(
+                    modifier = Modifier
+                        .horizontalListItemSpacing(
+                            itemPosition = index,
+                            spacingHorizontal = 5.dp,
+                            spacingVertical = TempoTheme.dimensions.spaceXS,
+                            includeEdge = false
+                        )
+                        .size(21.dp)
+                        .clip(CircleShape)
+                        .background(color = timeType.color, shape = CircleShape),
+                    contentAlignment = Alignment.Center
+                ) {
+                    TempoText(
+                        modifier = Modifier.testTag(
+                            RoutineItemSegmentTypeCountTestTag.replace(
+                                oldValue = "{{TYPE}}",
+                                newValue = timeType.id
+                            )
+                        ),
+                        text = count.toString(),
+                        style = TempoTheme.typography.h6
+                    )
+                }
+
+            }
         }
     }
 }

--- a/features/routines/src/test/java/com/enricog/features/routines/list/RoutinesStateConverterTest.kt
+++ b/features/routines/src/test/java/com/enricog/features/routines/list/RoutinesStateConverterTest.kt
@@ -1,11 +1,16 @@
 package com.enricog.features.routines.list
 
 import com.enricog.core.compose.api.classes.immutableListOf
+import com.enricog.core.compose.api.classes.immutableMapOf
 import com.enricog.core.coroutines.testing.CoroutineRule
+import com.enricog.data.routines.api.entities.Segment
 import com.enricog.data.routines.testing.entities.EMPTY
 import com.enricog.entities.asID
+import com.enricog.entities.seconds
 import com.enricog.features.routines.R
+import com.enricog.features.routines.detail.ui.time_type.TimeType
 import com.enricog.features.routines.list.models.RoutinesItem
+import com.enricog.features.routines.list.models.RoutinesItem.RoutineItem.SegmentsSummary
 import com.enricog.features.routines.list.models.RoutinesState
 import com.enricog.features.routines.list.models.RoutinesState.Data.Action
 import com.enricog.features.routines.list.models.RoutinesViewState
@@ -14,6 +19,7 @@ import org.junit.Rule
 import org.junit.Test
 import kotlin.test.assertEquals
 import com.enricog.data.routines.api.entities.Routine.Companion as RoutineEntity
+import com.enricog.data.routines.api.entities.TimeType as TimeTypeEntity
 
 class RoutinesStateConverterTest {
 
@@ -23,7 +29,7 @@ class RoutinesStateConverterTest {
     private val sut = RoutinesStateConverter()
 
     @Test
-    fun `test map idle`() = coroutineRule {
+    fun `should map idle state`() = coroutineRule {
         val state = RoutinesState.Idle
         val viewState = RoutinesViewState.Idle
 
@@ -33,7 +39,7 @@ class RoutinesStateConverterTest {
     }
 
     @Test
-    fun `test map empty`() = coroutineRule {
+    fun `should map empty state`() = coroutineRule {
         val state = RoutinesState.Empty
         val viewState = RoutinesViewState.Empty
 
@@ -43,24 +49,128 @@ class RoutinesStateConverterTest {
     }
 
     @Test
-    fun `test map data`() = coroutineRule {
-        val routineEntity = RoutineEntity.EMPTY
-        val routineItem = RoutinesItem.RoutineItem(id = 0.asID, name = "", rank = "aaaaaa")
-        val state = RoutinesState.Data(routines = listOf(routineEntity), action = null)
-        val viewState = RoutinesViewState.Data(
-            routinesItems = immutableListOf(routineItem, RoutinesItem.Space),
-            message = null
-        )
+    fun `should map data state with segments summary null when routine has not segment`() =
+        coroutineRule {
+            val routineEntity = RoutineEntity.EMPTY.copy(
+                name = "Routine",
+                segments = emptyList()
+            )
+            val routineItem = RoutinesItem.RoutineItem(
+                id = 0.asID,
+                name = "Routine",
+                rank = "aaaaaa",
+                segmentsSummary = null
+            )
+            val state = RoutinesState.Data(routines = listOf(routineEntity), action = null)
+            val viewState = RoutinesViewState.Data(
+                routinesItems = immutableListOf(routineItem, RoutinesItem.Space),
+                message = null
+            )
 
-        val result = sut.convert(state)
+            val result = sut.convert(state)
 
-        assertEquals(viewState, result)
-    }
+            assertEquals(viewState, result)
+        }
+
+    @Test
+    fun `should map data state with segments summary when routine has at least one segment`() =
+        coroutineRule {
+            val routineEntity = RoutineEntity.EMPTY.copy(
+                name = "Routine",
+                segments = listOf(
+                    Segment.EMPTY.copy(
+                        name = "Segment 1",
+                        time = 5.seconds,
+                        type = TimeTypeEntity.TIMER
+                    ),
+                    Segment.EMPTY.copy(
+                        name = "Segment 2",
+                        time = 4.seconds,
+                        type = TimeTypeEntity.REST
+                    ),
+                    Segment.EMPTY.copy(
+                        name = "Segment 3",
+                        time = 3.seconds,
+                        type = TimeTypeEntity.TIMER
+                    ),
+                    Segment.EMPTY.copy(
+                        name = "Segment 4",
+                        time = 0.seconds,
+                        type = TimeTypeEntity.STOPWATCH
+                    ),
+                )
+            )
+            val routineItem = RoutinesItem.RoutineItem(
+                id = 0.asID,
+                name = "Routine",
+                rank = "aaaaaa",
+                segmentsSummary = SegmentsSummary(
+                    totalTime = 12.seconds,
+                    segmentTypesCount = immutableMapOf(
+                        TimeType.from(TimeTypeEntity.TIMER) to 2,
+                        TimeType.from(TimeTypeEntity.REST) to 1,
+                        TimeType.from(TimeTypeEntity.STOPWATCH) to 1
+                    )
+                )
+            )
+            val state = RoutinesState.Data(routines = listOf(routineEntity), action = null)
+            val viewState = RoutinesViewState.Data(
+                routinesItems = immutableListOf(routineItem, RoutinesItem.Space),
+                message = null
+            )
+
+            val result = sut.convert(state)
+
+            assertEquals(viewState, result)
+        }
+
+    @Test
+    fun `should map data state with segments summary with no total time when routine has only stopwatch segment`() =
+        coroutineRule {
+            val routineEntity = RoutineEntity.EMPTY.copy(
+                name = "Routine",
+                segments = listOf(
+                    Segment.EMPTY.copy(
+                        name = "Segment 1",
+                        time = 0.seconds,
+                        type = TimeTypeEntity.STOPWATCH
+                    ),
+                )
+            )
+            val routineItem = RoutinesItem.RoutineItem(
+                id = 0.asID,
+                name = "Routine",
+                rank = "aaaaaa",
+                segmentsSummary = SegmentsSummary(
+                    totalTime = null,
+                    segmentTypesCount = immutableMapOf(
+                        TimeType.from(TimeTypeEntity.STOPWATCH) to 1
+                    )
+                )
+            )
+            val state = RoutinesState.Data(routines = listOf(routineEntity), action = null)
+            val viewState = RoutinesViewState.Data(
+                routinesItems = immutableListOf(routineItem, RoutinesItem.Space),
+                message = null
+            )
+
+            val result = sut.convert(state)
+
+            assertEquals(viewState, result)
+        }
 
     @Test
     fun `test map data with delete routine error action`() = coroutineRule {
-        val routineEntity = RoutineEntity.EMPTY
-        val routineItem = RoutinesItem.RoutineItem(id = 0.asID, name = "", rank = "aaaaaa")
+        val routineEntity = RoutineEntity.EMPTY.copy(
+            name = "Routine",
+            segments = emptyList()
+        )
+        val routineItem = RoutinesItem.RoutineItem(
+            id = 0.asID,
+            name = "Routine",
+            rank = "aaaaaa",
+            segmentsSummary = null
+        )
         val state = RoutinesState.Data(
             routines = listOf(routineEntity),
             action = Action.DeleteRoutineError(routineEntity.id)
@@ -79,9 +189,17 @@ class RoutinesStateConverterTest {
     }
 
     @Test
-    fun `test map data with move routine error action`() = coroutineRule {
-        val routineEntity = RoutineEntity.EMPTY
-        val routineItem = RoutinesItem.RoutineItem(id = 0.asID, name = "", rank = "aaaaaa")
+    fun `should map data with move routine error action`() = coroutineRule {
+        val routineEntity = RoutineEntity.EMPTY.copy(
+            name = "Routine",
+            segments = emptyList()
+        )
+        val routineItem = RoutinesItem.RoutineItem(
+            id = 0.asID,
+            name = "Routine",
+            rank = "aaaaaa",
+            segmentsSummary = null
+        )
         val state = RoutinesState.Data(
             routines = listOf(routineEntity),
             action = Action.MoveRoutineError
@@ -100,7 +218,7 @@ class RoutinesStateConverterTest {
     }
 
     @Test
-    fun `test map error`() = coroutineRule {
+    fun `should map error`() = coroutineRule {
         val exception = Exception("something went wrong")
         val state = RoutinesState.Error(throwable = exception)
         val viewState = RoutinesViewState.Error(throwable = exception)

--- a/features/routines/src/test/java/com/enricog/features/routines/list/RoutinesViewModelTest.kt
+++ b/features/routines/src/test/java/com/enricog/features/routines/list/RoutinesViewModelTest.kt
@@ -47,12 +47,14 @@ class RoutinesViewModelTest {
     private val firstRoutine = RoutinesItem.RoutineItem(
         id = 1.asID,
         name = "First Routine",
-        rank = "aaaaaa"
+        rank = "aaaaaa",
+        segmentsSummary = null
     )
     private val secondRoutine = RoutinesItem.RoutineItem(
         id = 2.asID,
         name = "Second Routine",
-        rank = "bbbbbb"
+        rank = "bbbbbb",
+        segmentsSummary = null
     )
     private val navigator = FakeNavigator()
     private val store = FakeStore(listOf(firstRoutineEntity, secondRoutineEntity))

--- a/ui/components/src/main/java/com/enricog/ui/components/extensions/SecondsExtensions.kt
+++ b/ui/components/src/main/java/com/enricog/ui/components/extensions/SecondsExtensions.kt
@@ -10,9 +10,12 @@ fun Seconds.format(): String {
     return buildString {
         val (m, s) = inMinutes
         if (m > 0) {
-            append("$m${stringResource(id = R.string.label_minutes_acronym)} ")
+            append("$m${stringResource(id = R.string.label_minutes_acronym)}")
         }
         if (s > 0) {
+            if (m > 0) {
+                append(" ")
+            }
             append("$s${stringResource(id = R.string.label_seconds_acronym)}")
         }
     }


### PR DESCRIPTION
Show the routine's segments summary in the list of routines, the following info are shown:
- Total amout of time of each segment
- Number of segments per type

If the routine has not segments no data is shown.
If the routine contains only stopwatch segments the total amount of time is not displayed.

<img src="https://user-images.githubusercontent.com/13453791/209985601-ca60be26-ae3b-493e-b4cf-9102ad10a2c6.png" alt="screenshot with changes" width="300"/>
