### PR TITLE
Fix: segment detail tabs background size and keyboard behaviour

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="deploymentTargetDropDown">
-    <targetSelectedWithDropDown>
+    <runningDeviceTargetSelectedWithDropDown>
       <Target>
-        <type value="QUICK_BOOT_TARGET" />
+        <type value="RUNNING_DEVICE_TARGET" />
         <deviceKey>
           <Key>
-            <type value="VIRTUAL_DEVICE_PATH" />
-            <value value="C:\Users\fd\.android\avd\Pixel_4_API_R.avd" />
+            <type value="SERIAL_NUMBER" />
+            <value value="19291FDF6002X0" />
           </Key>
         </deviceKey>
       </Target>
-    </targetSelectedWithDropDown>
-    <timeTargetWasSelectedWithDropDown value="2022-12-26T10:59:21.683275300Z" />
+    </runningDeviceTargetSelectedWithDropDown>
+    <timeTargetWasSelectedWithDropDown value="2023-01-01T09:34:36.342706800Z" />
   </component>
 </project>

--- a/features/routines/src/main/java/com/enricog/features/routines/detail/segment/ui_components/SegmentFormScene.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/detail/segment/ui_components/SegmentFormScene.kt
@@ -93,9 +93,17 @@ internal fun SegmentFormScene(
                     labelText = stringResource(R.string.field_label_segment_name),
                     errorText = stringResourceOrNull(id = state.errors[SegmentField.Name]?.stringResId),
                     singleLine = true,
-                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
+                    keyboardOptions = KeyboardOptions(
+                        imeAction = if (state.segment.time != null) ImeAction.Next else ImeAction.Done
+                    ),
                     keyboardActions = KeyboardActions(
-                        onNext = { segmentTimeRef.requestFocus() }
+                        onNext = {
+                            if (state.segment.time != null) {
+                                segmentTimeRef.requestFocus()
+                            } else {
+                                keyboardController?.hide()
+                            }
+                        }
                     )
                 )
 

--- a/features/routines/src/main/java/com/enricog/features/routines/detail/segment/ui_components/SegmentTypeTabs.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/detail/segment/ui_components/SegmentTypeTabs.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.runtime.Composable
@@ -15,6 +14,7 @@ import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import com.enricog.core.compose.api.classes.ImmutableList
 import com.enricog.core.compose.api.classes.ImmutableMap
 import com.enricog.core.compose.api.modifiers.spacing.horizontalListItemSpacing
@@ -22,7 +22,6 @@ import com.enricog.core.compose.api.modifiers.swipeable.FractionalThreshold
 import com.enricog.core.compose.api.modifiers.swipeable.SwipeableState
 import com.enricog.core.compose.api.modifiers.swipeable.swipeable
 import com.enricog.features.routines.detail.ui.time_type.TimeType
-import com.enricog.ui.theme.TempoTheme
 import kotlinx.coroutines.launch
 
 @Composable
@@ -46,7 +45,7 @@ internal fun SegmentTypeTabs(
                     color = selectedTimeType.color,
                     cornerRadius = CornerRadius(x = 50f, y = 50f),
                     topLeft = Offset(x = swipeState.offset.value, y = tabSpace.toPx()),
-                    size = Size(width = tabWidth.toPx(), height = 85f)
+                    size = Size(width = tabWidth.toPx(), height = 31.dp.toPx())
                 )
             }
     ) {


### PR DESCRIPTION
Fix in the segment detail screen 2 issues:
- The background in the tabs was not dp dependent, which made the background not scale correctly based on the device
- Change the behavior of the keyboard's next button when the segment name field is focused, if the time field is not showing change the IME action to Done and close the keyboard instead of trying to focus the next field