### PR TITLE
Feature: Timer next and previous step

### DIFF
--- a/features/timer/src/androidTest/java/com/enricog/features/timer/TimerScreenKtTest.kt
+++ b/features/timer/src/androidTest/java/com/enricog/features/timer/TimerScreenKtTest.kt
@@ -68,7 +68,7 @@ class TimerScreenKtTest {
                     iconResId = R.drawable.ic_timer_next,
                     contentDescriptionResId = R.string.content_description_button_next_routine_segment,
                     size = TempoIconButtonSize.Normal
-                ),
+                )
             )
         )
 

--- a/features/timer/src/androidTest/java/com/enricog/features/timer/TimerScreenKtTest.kt
+++ b/features/timer/src/androidTest/java/com/enricog/features/timer/TimerScreenKtTest.kt
@@ -29,6 +29,7 @@ class TimerScreenKtTest {
                 viewState.Compose(
                     onPlay = {},
                     onBack = {},
+                    onNext = {},
                     onReset = {},
                     onDone = {},
                     onRetryLoad = {}
@@ -53,7 +54,7 @@ class TimerScreenKtTest {
             ),
             isSoundEnabled = true,
             timerActions = TimerViewState.Counting.Actions(
-                next = TimerViewState.Counting.Actions.Button(
+                back = TimerViewState.Counting.Actions.Button(
                     iconResId = R.drawable.ic_timer_back,
                     contentDescriptionResId = R.string.content_description_button_back_routine_segment,
                     size = TempoIconButtonSize.Normal
@@ -62,7 +63,12 @@ class TimerScreenKtTest {
                     iconResId =  R.drawable.ic_timer_stop,
                     contentDescriptionResId =  R.string.content_description_button_stop_routine_segment,
                     size = TempoIconButtonSize.Normal
-                )
+                ),
+                next = TimerViewState.Counting.Actions.Button(
+                    iconResId = R.drawable.ic_timer_next,
+                    contentDescriptionResId = R.string.content_description_button_next_routine_segment,
+                    size = TempoIconButtonSize.Normal
+                ),
             )
         )
 
@@ -71,6 +77,7 @@ class TimerScreenKtTest {
                 viewState.Compose(
                     onPlay = {},
                     onBack = {},
+                    onNext = {},
                     onReset = {},
                     onDone = {},
                     onRetryLoad = {}
@@ -92,6 +99,7 @@ class TimerScreenKtTest {
                 viewState.Compose(
                     onPlay = {},
                     onBack = {},
+                    onNext = {},
                     onReset = {},
                     onDone = {},
                     onRetryLoad = {}
@@ -113,6 +121,7 @@ class TimerScreenKtTest {
                 viewState.Compose(
                     onPlay = {},
                     onBack = {},
+                    onNext = {},
                     onReset = {},
                     onDone = {},
                     onRetryLoad = {}

--- a/features/timer/src/androidTest/java/com/enricog/features/timer/TimerScreenKtTest.kt
+++ b/features/timer/src/androidTest/java/com/enricog/features/timer/TimerScreenKtTest.kt
@@ -27,8 +27,8 @@ class TimerScreenKtTest {
         setContent {
             TempoTheme {
                 viewState.Compose(
-                    onToggleTimer = {},
-                    onRestartSegment = {},
+                    onPlay = {},
+                    onBack = {},
                     onReset = {},
                     onDone = {},
                     onRetryLoad = {}
@@ -53,12 +53,12 @@ class TimerScreenKtTest {
             ),
             isSoundEnabled = true,
             timerActions = TimerViewState.Counting.Actions(
-                restart = TimerViewState.Counting.Actions.Button(
+                next = TimerViewState.Counting.Actions.Button(
                     iconResId = R.drawable.ic_timer_back,
-                    contentDescriptionResId = R.string.content_description_button_restart_routine_segment,
+                    contentDescriptionResId = R.string.content_description_button_back_routine_segment,
                     size = TempoIconButtonSize.Normal
                 ),
-                toggleStart = TimerViewState.Counting.Actions.Button(
+                play = TimerViewState.Counting.Actions.Button(
                     iconResId =  R.drawable.ic_timer_stop,
                     contentDescriptionResId =  R.string.content_description_button_stop_routine_segment,
                     size = TempoIconButtonSize.Normal
@@ -69,8 +69,8 @@ class TimerScreenKtTest {
         setContent {
             TempoTheme {
                 viewState.Compose(
-                    onToggleTimer = {},
-                    onRestartSegment = {},
+                    onPlay = {},
+                    onBack = {},
                     onReset = {},
                     onDone = {},
                     onRetryLoad = {}
@@ -90,8 +90,8 @@ class TimerScreenKtTest {
         setContent {
             TempoTheme {
                 viewState.Compose(
-                    onToggleTimer = {},
-                    onRestartSegment = {},
+                    onPlay = {},
+                    onBack = {},
                     onReset = {},
                     onDone = {},
                     onRetryLoad = {}
@@ -111,8 +111,8 @@ class TimerScreenKtTest {
         setContent {
             TempoTheme {
                 viewState.Compose(
-                    onToggleTimer = {},
-                    onRestartSegment = {},
+                    onPlay = {},
+                    onBack = {},
                     onReset = {},
                     onDone = {},
                     onRetryLoad = {}

--- a/features/timer/src/androidTest/java/com/enricog/features/timer/ui_components/ActionsBarKtTest.kt
+++ b/features/timer/src/androidTest/java/com/enricog/features/timer/ui_components/ActionsBarKtTest.kt
@@ -23,19 +23,19 @@ class ActionsBarKtTest {
             TempoTheme {
                 ActionsBar(
                     timerActions = TimerViewState.Counting.Actions(
-                        restart = TimerViewState.Counting.Actions.Button(
+                        next = TimerViewState.Counting.Actions.Button(
                             iconResId = R.drawable.ic_timer_back,
-                            contentDescriptionResId = R.string.content_description_button_restart_routine_segment,
+                            contentDescriptionResId = R.string.content_description_button_back_routine_segment,
                             size = TempoIconButtonSize.Normal
                         ),
-                        toggleStart = TimerViewState.Counting.Actions.Button(
+                        play = TimerViewState.Counting.Actions.Button(
                             iconResId = R.drawable.ic_timer_stop,
                             contentDescriptionResId = R.string.content_description_button_stop_routine_segment,
                             size = TempoIconButtonSize.Normal
                         )
                     ),
-                    onStartStopButtonClick = {},
-                    onRestartSegmentButtonClick = {}
+                    onPlayButtonClick = {},
+                    onBackButtonClick = {}
                 )
             }
         }
@@ -44,7 +44,7 @@ class ActionsBarKtTest {
             assertIsDisplayed()
             assertDrawable(R.drawable.ic_timer_stop)
         }
-        onNodeWithTag(ButtonRestartTestTag).run {
+        onNodeWithTag(ButtonBackTestTag).run {
             assertIsDisplayed()
             assertDrawable(R.drawable.ic_timer_back)
         }

--- a/features/timer/src/androidTest/java/com/enricog/features/timer/ui_components/ActionsBarKtTest.kt
+++ b/features/timer/src/androidTest/java/com/enricog/features/timer/ui_components/ActionsBarKtTest.kt
@@ -23,7 +23,7 @@ class ActionsBarKtTest {
             TempoTheme {
                 ActionsBar(
                     timerActions = TimerViewState.Counting.Actions(
-                        next = TimerViewState.Counting.Actions.Button(
+                        back = TimerViewState.Counting.Actions.Button(
                             iconResId = R.drawable.ic_timer_back,
                             contentDescriptionResId = R.string.content_description_button_back_routine_segment,
                             size = TempoIconButtonSize.Normal
@@ -32,10 +32,16 @@ class ActionsBarKtTest {
                             iconResId = R.drawable.ic_timer_stop,
                             contentDescriptionResId = R.string.content_description_button_stop_routine_segment,
                             size = TempoIconButtonSize.Normal
-                        )
+                        ),
+                        next = TimerViewState.Counting.Actions.Button(
+                            iconResId = R.drawable.ic_timer_next,
+                            contentDescriptionResId = R.string.content_description_button_next_routine_segment,
+                            size = TempoIconButtonSize.Normal
+                        ),
                     ),
                     onPlayButtonClick = {},
-                    onBackButtonClick = {}
+                    onBackButtonClick = {},
+                    onNextButtonClick = {}
                 )
             }
         }
@@ -47,6 +53,10 @@ class ActionsBarKtTest {
         onNodeWithTag(ButtonBackTestTag).run {
             assertIsDisplayed()
             assertDrawable(R.drawable.ic_timer_back)
+        }
+        onNodeWithTag(ButtonNextTestTag).run {
+            assertIsDisplayed()
+            assertDrawable(R.drawable.ic_timer_next)
         }
     }
 }

--- a/features/timer/src/androidTest/java/com/enricog/features/timer/ui_components/TimerCountingSceneKtTest.kt
+++ b/features/timer/src/androidTest/java/com/enricog/features/timer/ui_components/TimerCountingSceneKtTest.kt
@@ -31,7 +31,7 @@ class TimerCountingSceneKtTest {
             ),
             isSoundEnabled = true,
             timerActions = TimerViewState.Counting.Actions(
-                next = TimerViewState.Counting.Actions.Button(
+                back = TimerViewState.Counting.Actions.Button(
                     iconResId = R.drawable.ic_timer_back,
                     contentDescriptionResId = R.string.content_description_button_back_routine_segment,
                     size = TempoIconButtonSize.Normal
@@ -39,6 +39,11 @@ class TimerCountingSceneKtTest {
                 play = TimerViewState.Counting.Actions.Button(
                     iconResId =  R.drawable.ic_timer_stop,
                     contentDescriptionResId =  R.string.content_description_button_stop_routine_segment,
+                    size = TempoIconButtonSize.Normal
+                ),
+                next = TimerViewState.Counting.Actions.Button(
+                    iconResId = R.drawable.ic_timer_next,
+                    contentDescriptionResId = R.string.content_description_button_next_routine_segment,
                     size = TempoIconButtonSize.Normal
                 )
             )
@@ -49,7 +54,8 @@ class TimerCountingSceneKtTest {
                 TimerCountingScene(
                     state = viewState,
                     onPlay = {},
-                    onBack = {}
+                    onBack = {},
+                    onNext = {}
                 )
             }
         }
@@ -72,7 +78,7 @@ class TimerCountingSceneKtTest {
             ),
             isSoundEnabled = true,
             timerActions = TimerViewState.Counting.Actions(
-                next = TimerViewState.Counting.Actions.Button(
+                back = TimerViewState.Counting.Actions.Button(
                     iconResId = R.drawable.ic_timer_back,
                     contentDescriptionResId = R.string.content_description_button_back_routine_segment,
                     size = TempoIconButtonSize.Normal
@@ -80,6 +86,11 @@ class TimerCountingSceneKtTest {
                 play = TimerViewState.Counting.Actions.Button(
                     iconResId =  R.drawable.ic_timer_stop,
                     contentDescriptionResId =  R.string.content_description_button_stop_routine_segment,
+                    size = TempoIconButtonSize.Normal
+                ),
+                next = TimerViewState.Counting.Actions.Button(
+                    iconResId = R.drawable.ic_timer_next,
+                    contentDescriptionResId = R.string.content_description_button_next_routine_segment,
                     size = TempoIconButtonSize.Normal
                 )
             )
@@ -90,7 +101,8 @@ class TimerCountingSceneKtTest {
                 TimerCountingScene(
                     state = viewState,
                     onPlay = {},
-                    onBack = {}
+                    onBack = {},
+                    onNext = {}
                 )
             }
         }

--- a/features/timer/src/androidTest/java/com/enricog/features/timer/ui_components/TimerCountingSceneKtTest.kt
+++ b/features/timer/src/androidTest/java/com/enricog/features/timer/ui_components/TimerCountingSceneKtTest.kt
@@ -31,12 +31,12 @@ class TimerCountingSceneKtTest {
             ),
             isSoundEnabled = true,
             timerActions = TimerViewState.Counting.Actions(
-                restart = TimerViewState.Counting.Actions.Button(
+                next = TimerViewState.Counting.Actions.Button(
                     iconResId = R.drawable.ic_timer_back,
-                    contentDescriptionResId = R.string.content_description_button_restart_routine_segment,
+                    contentDescriptionResId = R.string.content_description_button_back_routine_segment,
                     size = TempoIconButtonSize.Normal
                 ),
-                toggleStart = TimerViewState.Counting.Actions.Button(
+                play = TimerViewState.Counting.Actions.Button(
                     iconResId =  R.drawable.ic_timer_stop,
                     contentDescriptionResId =  R.string.content_description_button_stop_routine_segment,
                     size = TempoIconButtonSize.Normal
@@ -48,8 +48,8 @@ class TimerCountingSceneKtTest {
             TempoTheme {
                 TimerCountingScene(
                     state = viewState,
-                    onToggleTimer = {},
-                    onRestartSegment = {}
+                    onPlay = {},
+                    onBack = {}
                 )
             }
         }
@@ -72,12 +72,12 @@ class TimerCountingSceneKtTest {
             ),
             isSoundEnabled = true,
             timerActions = TimerViewState.Counting.Actions(
-                restart = TimerViewState.Counting.Actions.Button(
+                next = TimerViewState.Counting.Actions.Button(
                     iconResId = R.drawable.ic_timer_back,
-                    contentDescriptionResId = R.string.content_description_button_restart_routine_segment,
+                    contentDescriptionResId = R.string.content_description_button_back_routine_segment,
                     size = TempoIconButtonSize.Normal
                 ),
-                toggleStart = TimerViewState.Counting.Actions.Button(
+                play = TimerViewState.Counting.Actions.Button(
                     iconResId =  R.drawable.ic_timer_stop,
                     contentDescriptionResId =  R.string.content_description_button_stop_routine_segment,
                     size = TempoIconButtonSize.Normal
@@ -89,8 +89,8 @@ class TimerCountingSceneKtTest {
             TempoTheme {
                 TimerCountingScene(
                     state = viewState,
-                    onToggleTimer = {},
-                    onRestartSegment = {}
+                    onPlay = {},
+                    onBack = {}
                 )
             }
         }

--- a/features/timer/src/androidTest/java/com/enricog/features/timer/ui_components/TimerToolbarKtTest.kt
+++ b/features/timer/src/androidTest/java/com/enricog/features/timer/ui_components/TimerToolbarKtTest.kt
@@ -33,12 +33,12 @@ class TimerToolbarKtTest {
                         ),
                         isSoundEnabled = true,
                         timerActions = TimerViewState.Counting.Actions(
-                            restart = TimerViewState.Counting.Actions.Button(
+                            next = TimerViewState.Counting.Actions.Button(
                                 iconResId = R.drawable.ic_timer_back,
-                                contentDescriptionResId = R.string.content_description_button_restart_routine_segment,
+                                contentDescriptionResId = R.string.content_description_button_back_routine_segment,
                                 size = TempoIconButtonSize.Normal
                             ),
-                            toggleStart = TimerViewState.Counting.Actions.Button(
+                            play = TimerViewState.Counting.Actions.Button(
                                 iconResId =  R.drawable.ic_timer_stop,
                                 contentDescriptionResId =  R.string.content_description_button_stop_routine_segment,
                                 size = TempoIconButtonSize.Normal
@@ -72,12 +72,12 @@ class TimerToolbarKtTest {
                         ),
                         isSoundEnabled = false,
                         timerActions = TimerViewState.Counting.Actions(
-                            restart = TimerViewState.Counting.Actions.Button(
+                            next = TimerViewState.Counting.Actions.Button(
                                 iconResId = R.drawable.ic_timer_back,
-                                contentDescriptionResId = R.string.content_description_button_restart_routine_segment,
+                                contentDescriptionResId = R.string.content_description_button_back_routine_segment,
                                 size = TempoIconButtonSize.Normal
                             ),
-                            toggleStart = TimerViewState.Counting.Actions.Button(
+                            play = TimerViewState.Counting.Actions.Button(
                                 iconResId =  R.drawable.ic_timer_stop,
                                 contentDescriptionResId =  R.string.content_description_button_stop_routine_segment,
                                 size = TempoIconButtonSize.Normal

--- a/features/timer/src/androidTest/java/com/enricog/features/timer/ui_components/TimerToolbarKtTest.kt
+++ b/features/timer/src/androidTest/java/com/enricog/features/timer/ui_components/TimerToolbarKtTest.kt
@@ -33,7 +33,7 @@ class TimerToolbarKtTest {
                         ),
                         isSoundEnabled = true,
                         timerActions = TimerViewState.Counting.Actions(
-                            next = TimerViewState.Counting.Actions.Button(
+                            back = TimerViewState.Counting.Actions.Button(
                                 iconResId = R.drawable.ic_timer_back,
                                 contentDescriptionResId = R.string.content_description_button_back_routine_segment,
                                 size = TempoIconButtonSize.Normal
@@ -42,7 +42,12 @@ class TimerToolbarKtTest {
                                 iconResId =  R.drawable.ic_timer_stop,
                                 contentDescriptionResId =  R.string.content_description_button_stop_routine_segment,
                                 size = TempoIconButtonSize.Normal
-                            )
+                            ),
+                            next = TimerViewState.Counting.Actions.Button(
+                                iconResId = R.drawable.ic_timer_next,
+                                contentDescriptionResId = R.string.content_description_button_next_routine_segment,
+                                size = TempoIconButtonSize.Normal
+                            ),
                         )
                     ),
                     onCloseClick = { },
@@ -72,7 +77,7 @@ class TimerToolbarKtTest {
                         ),
                         isSoundEnabled = false,
                         timerActions = TimerViewState.Counting.Actions(
-                            next = TimerViewState.Counting.Actions.Button(
+                            back = TimerViewState.Counting.Actions.Button(
                                 iconResId = R.drawable.ic_timer_back,
                                 contentDescriptionResId = R.string.content_description_button_back_routine_segment,
                                 size = TempoIconButtonSize.Normal
@@ -81,7 +86,12 @@ class TimerToolbarKtTest {
                                 iconResId =  R.drawable.ic_timer_stop,
                                 contentDescriptionResId =  R.string.content_description_button_stop_routine_segment,
                                 size = TempoIconButtonSize.Normal
-                            )
+                            ),
+                            next = TimerViewState.Counting.Actions.Button(
+                                iconResId = R.drawable.ic_timer_next,
+                                contentDescriptionResId = R.string.content_description_button_next_routine_segment,
+                                size = TempoIconButtonSize.Normal
+                            ),
                         )
                     ),
                     onCloseClick = { },

--- a/features/timer/src/main/java/com/enricog/features/timer/TimerScreen.kt
+++ b/features/timer/src/main/java/com/enricog/features/timer/TimerScreen.kt
@@ -42,7 +42,7 @@ internal fun TimerScreen(viewModel: TimerViewModel) {
                 .zIndex(1f),
             state = viewState,
             onCloseClick = { showCloseDialog = true },
-            onSoundClick = viewModel::toggleSound
+            onSoundClick = viewModel::onToggleSound
         )
 
         AnimatedContent(
@@ -61,8 +61,9 @@ internal fun TimerScreen(viewModel: TimerViewModel) {
             }
         ) { targetViewState ->
             targetViewState.Compose(
-                onToggleTimer = viewModel::onToggleTimer,
-                onRestartSegment = viewModel::onRestartSegment,
+                onPlay = viewModel::onPlay,
+                onBack = viewModel::onBack,
+                onNext = viewModel::onNext,
                 onReset = viewModel::onReset,
                 onDone = viewModel::onDone,
                 onRetryLoad = viewModel::onRetryLoad
@@ -80,8 +81,9 @@ internal fun TimerScreen(viewModel: TimerViewModel) {
 
 @Composable
 internal fun TimerViewState.Compose(
-    onToggleTimer: () -> Unit,
-    onRestartSegment: () -> Unit,
+    onPlay: () -> Unit,
+    onBack: () -> Unit,
+    onNext: () -> Unit,
     onReset: () -> Unit,
     onDone: () -> Unit,
     onRetryLoad: () -> Unit
@@ -90,8 +92,9 @@ internal fun TimerViewState.Compose(
         TimerViewState.Idle -> Unit
         is TimerViewState.Counting -> TimerCountingScene(
             state = this,
-            onToggleTimer = onToggleTimer,
-            onRestartSegment = onRestartSegment
+            onPlay = onPlay,
+            onBack = onBack,
+            onNext = onNext
         )
         TimerViewState.Completed -> TimerCompletedScene(
             onReset = onReset,

--- a/features/timer/src/main/java/com/enricog/features/timer/TimerStateConverter.kt
+++ b/features/timer/src/main/java/com/enricog/features/timer/TimerStateConverter.kt
@@ -86,15 +86,20 @@ internal class TimerStateConverter @Inject constructor() :
 
     private fun TimerState.Counting.getActions(): TimerViewState.Counting.Actions {
         return TimerViewState.Counting.Actions(
-            restart = TimerViewState.Counting.Actions.Button(
+            back = TimerViewState.Counting.Actions.Button(
                 iconResId = R.drawable.ic_timer_back,
-                contentDescriptionResId = R.string.content_description_button_restart_routine_segment,
+                contentDescriptionResId = R.string.content_description_button_back_routine_segment,
                 size = TempoIconButtonSize.Normal
             ),
-            toggleStart = TimerViewState.Counting.Actions.Button(
+            play = TimerViewState.Counting.Actions.Button(
                 iconResId = if (step.count.isRunning) R.drawable.ic_timer_stop else R.drawable.ic_timer_play,
                 contentDescriptionResId = if (step.count.isRunning) R.string.content_description_button_stop_routine_segment else R.string.content_description_button_start_routine_segment,
                 size = if (runningSegment.type == TimeType.STOPWATCH) TempoIconButtonSize.Large else TempoIconButtonSize.Normal
+            ),
+            next = TimerViewState.Counting.Actions.Button(
+                iconResId = R.drawable.ic_timer_next,
+                contentDescriptionResId = R.string.content_description_button_next_routine_segment,
+                size = TempoIconButtonSize.Normal
             )
         )
     }

--- a/features/timer/src/main/java/com/enricog/features/timer/TimerStateConverter.kt
+++ b/features/timer/src/main/java/com/enricog/features/timer/TimerStateConverter.kt
@@ -28,7 +28,7 @@ internal class TimerStateConverter @Inject constructor() :
             TimerViewState.Completed
         } else {
             TimerViewState.Counting(
-                timeInSeconds = state.step.count.seconds.value,
+                timeInSeconds = state.runningStep.count.seconds.value,
                 stepTitleId = state.getStepTitleId(),
                 segmentName = state.runningSegment.name,
                 clockBackgroundColor = state.getClockBackgroundColor(),
@@ -40,9 +40,9 @@ internal class TimerStateConverter @Inject constructor() :
 
     private fun TimerState.Counting.getClockBackgroundColor(): BackgroundColor {
         val nextSegmentStep = nextSegmentStep
-        return when (step.type) {
+        return when (runningStep.type) {
             SegmentStepType.STARTING -> BackgroundColor(
-                background = step.type.getColor(),
+                background = runningStep.type.getColor(),
                 ripple = when {
                     isStepCountCompleted -> runningSegment.type.getColor()
                     else -> null
@@ -78,8 +78,8 @@ internal class TimerStateConverter @Inject constructor() :
     private fun TimerState.Counting.getStepTitleId(): Int {
         return when {
             runningSegment.type == TimeType.REST -> R.string.title_segment_time_type_rest
-            step.type == SegmentStepType.STARTING -> R.string.title_segment_step_type_starting
-            step.type == SegmentStepType.IN_PROGRESS -> R.string.title_segment_step_type_in_progress
+            runningStep.type == SegmentStepType.STARTING -> R.string.title_segment_step_type_starting
+            runningStep.type == SegmentStepType.IN_PROGRESS -> R.string.title_segment_step_type_in_progress
             else -> throw IllegalArgumentException("unhandled case")
         }
     }
@@ -92,8 +92,8 @@ internal class TimerStateConverter @Inject constructor() :
                 size = TempoIconButtonSize.Normal
             ),
             play = TimerViewState.Counting.Actions.Button(
-                iconResId = if (step.count.isRunning) R.drawable.ic_timer_stop else R.drawable.ic_timer_play,
-                contentDescriptionResId = if (step.count.isRunning) R.string.content_description_button_stop_routine_segment else R.string.content_description_button_start_routine_segment,
+                iconResId = if (runningStep.count.isRunning) R.drawable.ic_timer_stop else R.drawable.ic_timer_play,
+                contentDescriptionResId = if (runningStep.count.isRunning) R.string.content_description_button_stop_routine_segment else R.string.content_description_button_start_routine_segment,
                 size = if (runningSegment.type == TimeType.STOPWATCH) TempoIconButtonSize.Large else TempoIconButtonSize.Normal
             ),
             next = TimerViewState.Counting.Actions.Button(

--- a/features/timer/src/main/java/com/enricog/features/timer/TimerViewModel.kt
+++ b/features/timer/src/main/java/com/enricog/features/timer/TimerViewModel.kt
@@ -75,11 +75,11 @@ internal class TimerViewModel @Inject constructor(
     }
 
     fun onBack() {
-        updateState { reducer.timeBack(it) }
+        updateState { reducer.jumpStepBack(it) }
     }
 
     fun onNext() {
-        updateState {  reducer.timeNext(it) }
+        updateState {  reducer.jumpStepNext(it) }
     }
 
     fun onReset() {

--- a/features/timer/src/main/java/com/enricog/features/timer/TimerViewModel.kt
+++ b/features/timer/src/main/java/com/enricog/features/timer/TimerViewModel.kt
@@ -66,16 +66,20 @@ internal class TimerViewModel @Inject constructor(
         }
     }
 
-    fun onToggleTimer() {
+    fun onPlay() {
         updateState { reducer.toggleTimeRunning(it) }
     }
 
-    fun toggleSound() {
+    fun onToggleSound() {
         updateState { reducer.toggleSound(it) }
     }
 
-    fun onRestartSegment() {
-        updateState { reducer.restartTime(it) }
+    fun onBack() {
+        updateState { reducer.timeBack(it) }
+    }
+
+    fun onNext() {
+        updateState {  reducer.timeNext(it) }
     }
 
     fun onReset() {

--- a/features/timer/src/main/java/com/enricog/features/timer/models/SegmentStep.kt
+++ b/features/timer/src/main/java/com/enricog/features/timer/models/SegmentStep.kt
@@ -1,25 +1,10 @@
 package com.enricog.features.timer.models
 
-import com.enricog.data.routines.api.entities.Routine
 import com.enricog.data.routines.api.entities.Segment
-import com.enricog.data.routines.api.entities.TimeType
-import com.enricog.entities.seconds
 
 internal data class SegmentStep(
+    val id: Int,
+    val segment: Segment,
     val count: Count,
     val type: SegmentStepType
-) {
-    companion object {
-        fun from(routine: Routine, segment: Segment): SegmentStep {
-            val (type, time) = if (segment.type != TimeType.REST && routine.startTimeOffset > 0.seconds) {
-                SegmentStepType.STARTING to routine.startTimeOffset
-            } else {
-                SegmentStepType.IN_PROGRESS to segment.time
-            }
-            return SegmentStep(
-                count = Count.idle(seconds = time),
-                type = type
-            )
-        }
-    }
-}
+)

--- a/features/timer/src/main/java/com/enricog/features/timer/models/TimerState.kt
+++ b/features/timer/src/main/java/com/enricog/features/timer/models/TimerState.kt
@@ -11,48 +11,43 @@ internal sealed class TimerState {
 
     data class Counting(
         val routine: Routine,
-        val runningSegment: Segment,
-        val step: SegmentStep,
+        val runningStep: SegmentStep,
+        val steps: List<SegmentStep>,
         val isSoundEnabled: Boolean
     ) : TimerState() {
 
+        private val runningStepIndex: Int
+            get() = steps.indexOfFirst { it.id == runningStep.id }
+
+        val runningSegment: Segment
+            get() = runningStep.segment
+
+        val nextSegment: Segment?
+            get() = nextSegmentStep?.segment
+
+        val nextSegmentStep: SegmentStep?
+            get() = steps.getOrNull(index = runningStepIndex + 1)
+
+        val previousSegmentStep: SegmentStep?
+            get() = steps.getOrNull(index = runningStepIndex - 1)
+
         val isStepCountRunning: Boolean
-            get() = step.count.isRunning && !step.count.isCompleted
+            get() = runningStep.count.isRunning && !runningStep.count.isCompleted
 
         val isStepCountCompleted: Boolean
-            get() = step.count.isCompleted
+            get() = runningStep.count.isCompleted
 
         val isStepCountCompleting: Boolean
             get() = isStepCountRunning && !isStopwatchRunning &&
-                    step.count.seconds <= STEP_COMPLETING_THRESHOLD
+                runningStep.count.seconds <= STEP_COMPLETING_THRESHOLD
 
         val isRoutineCompleted: Boolean
-            get() = routine.segments.indexOf(runningSegment) == routine.segments.size - 1 &&
-                    step.type == SegmentStepType.IN_PROGRESS &&
-                    step.count.isCompleted
+            get() = nextSegment == null && runningStep.count.isCompleted
 
         val isStopwatchRunning: Boolean
             get() = runningSegment.type == TimeType.STOPWATCH &&
-                    step.type == SegmentStepType.IN_PROGRESS &&
-                    isStepCountRunning
-
-        val nextSegment: Segment?
-            get() {
-                val indexRunningSegment = routine.segments.indexOf(runningSegment)
-                return routine.segments.getOrNull(indexRunningSegment + 1)
-            }
-
-        val nextSegmentStep: SegmentStep?
-            get() = nextSegment?.let { SegmentStep.from(routine = routine, segment = it) }
-
-        val previousSegment: Segment?
-            get() {
-                val indexRunningSegment = routine.segments.indexOf(runningSegment)
-                return routine.segments.getOrNull(indexRunningSegment - 1)
-            }
-
-        val previousSegmentStep: SegmentStep?
-            get() = previousSegment?.let { SegmentStep.from(routine = routine, segment = it) }
+                runningStep.type == SegmentStepType.IN_PROGRESS &&
+                isStepCountRunning
 
         private companion object {
             val STEP_COMPLETING_THRESHOLD = 5.seconds

--- a/features/timer/src/main/java/com/enricog/features/timer/models/TimerState.kt
+++ b/features/timer/src/main/java/com/enricog/features/timer/models/TimerState.kt
@@ -45,6 +45,15 @@ internal sealed class TimerState {
         val nextSegmentStep: SegmentStep?
             get() = nextSegment?.let { SegmentStep.from(routine = routine, segment = it) }
 
+        val previousSegment: Segment?
+            get() {
+                val indexRunningSegment = routine.segments.indexOf(runningSegment)
+                return routine.segments.getOrNull(indexRunningSegment - 1)
+            }
+
+        val previousSegmentStep: SegmentStep?
+            get() = previousSegment?.let { SegmentStep.from(routine = routine, segment = it) }
+
         private companion object {
             val STEP_COMPLETING_THRESHOLD = 5.seconds
         }

--- a/features/timer/src/main/java/com/enricog/features/timer/models/TimerViewState.kt
+++ b/features/timer/src/main/java/com/enricog/features/timer/models/TimerViewState.kt
@@ -24,8 +24,9 @@ internal sealed class TimerViewState {
         )
 
         data class Actions(
-            val restart: Button,
-            val toggleStart: Button
+            val next: Button,
+            val back: Button,
+            val play: Button
         ) {
             data class Button(
                 @DrawableRes val iconResId: Int,

--- a/features/timer/src/main/java/com/enricog/features/timer/ui_components/ActionsBar.kt
+++ b/features/timer/src/main/java/com/enricog/features/timer/ui_components/ActionsBar.kt
@@ -26,26 +26,30 @@ import com.enricog.ui.theme.TempoTheme
 
 internal const val ActionBarTestTag = "ActionBarTestTag"
 internal const val ButtonToggleStartTestTag = "ButtonToggleStartTestTag"
-internal const val ButtonRestartTestTag = "ButtonRestartTestTag"
+internal const val ButtonBackTestTag = "ButtonBackTestTag"
+internal const val ButtonNextTestTag = "ButtonNextTestTag"
 
 @Composable
 internal fun ActionsBar(
     timerActions: Actions,
-    onStartStopButtonClick: () -> Unit,
-    onRestartSegmentButtonClick: () -> Unit,
+    onPlayButtonClick: () -> Unit,
+    onBackButtonClick: () -> Unit,
+    onNextButtonClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     when (ScreenConfiguration.orientation) {
         PORTRAIT -> ActionsBarPortrait(
             timerActions = timerActions,
-            onStartStopButtonClick = onStartStopButtonClick,
-            onRestartSegmentButtonClick = onRestartSegmentButtonClick,
+            onPlayButtonClick = onPlayButtonClick,
+            onBackButtonClick = onBackButtonClick,
+            onNextButtonClick = onNextButtonClick,
             modifier = modifier
         )
         LANDSCAPE -> ActionsBarLandscape(
             timerActions = timerActions,
-            onStartStopButtonClick = onStartStopButtonClick,
-            onRestartSegmentButtonClick = onRestartSegmentButtonClick,
+            onPlayButtonClick = onPlayButtonClick,
+            onBackButtonClick = onBackButtonClick,
+            onNextButtonClick = onNextButtonClick,
             modifier = modifier
         )
     }
@@ -54,8 +58,9 @@ internal fun ActionsBar(
 @Composable
 private fun ActionsBarPortrait(
     timerActions: Actions,
-    onStartStopButtonClick: () -> Unit,
-    onRestartSegmentButtonClick: () -> Unit,
+    onPlayButtonClick: () -> Unit,
+    onBackButtonClick: () -> Unit,
+    onNextButtonClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     Container(
@@ -64,42 +69,65 @@ private fun ActionsBarPortrait(
             .fillMaxWidth()
     ) {
         ConstraintLayout(modifier = Modifier.fillMaxSize()) {
-            val (restartButton, spacer, toggleStartButton) = createRefs()
+            val (backButton, spacer1, spacer2, playButton, nextButton) = createRefs()
             createHorizontalChain(
-                restartButton,
-                spacer,
-                toggleStartButton,
+                backButton,
+                spacer1,
+                playButton,
+                spacer2,
+                nextButton,
                 chainStyle = ChainStyle.Packed
             )
 
-            RestartButton(
-                restartButton = timerActions.restart,
-                onClick = onRestartSegmentButtonClick,
-                modifier = Modifier.constrainAs(restartButton) {
+            BackButton(
+                backButton = timerActions.back,
+                onClick = onBackButtonClick,
+                modifier = Modifier.constrainAs(backButton) {
                     top.linkTo(parent.top)
                     bottom.linkTo(parent.bottom)
                     start.linkTo(parent.start)
-                    end.linkTo(spacer.start)
+                    end.linkTo(spacer1.start)
                 }
             )
             Spacer(
                 modifier = Modifier
                     .width(20.dp)
                     .height(20.dp)
-                    .constrainAs(spacer) {
+                    .constrainAs(spacer1) {
                         top.linkTo(parent.top)
                         bottom.linkTo(parent.bottom)
-                        start.linkTo(restartButton.end)
-                        end.linkTo(toggleStartButton.start)
+                        start.linkTo(backButton.end)
+                        end.linkTo(playButton.start)
                     }
             )
-            ToggleStartButton(
-                toggleStartButton = timerActions.toggleStart,
-                onClick = onStartStopButtonClick,
-                modifier = Modifier.constrainAs(toggleStartButton) {
+            PlayButton(
+                playButton = timerActions.play,
+                onClick = onPlayButtonClick,
+                modifier = Modifier.constrainAs(playButton) {
                     top.linkTo(parent.top)
                     bottom.linkTo(parent.bottom)
-                    start.linkTo(spacer.end)
+                    start.linkTo(spacer1.end)
+                    end.linkTo(spacer2.start)
+                }
+            )
+            Spacer(
+                modifier = Modifier
+                    .width(20.dp)
+                    .height(20.dp)
+                    .constrainAs(spacer2) {
+                        top.linkTo(parent.top)
+                        bottom.linkTo(parent.bottom)
+                        start.linkTo(playButton.end)
+                        end.linkTo(nextButton.start)
+                    }
+            )
+            NextButton(
+                nextButton = timerActions.next,
+                onClick = onNextButtonClick,
+                modifier = Modifier.constrainAs(nextButton) {
+                    top.linkTo(parent.top)
+                    bottom.linkTo(parent.bottom)
+                    start.linkTo(spacer2.end)
                     end.linkTo(parent.end)
                 }
             )
@@ -110,8 +138,9 @@ private fun ActionsBarPortrait(
 @Composable
 private fun ActionsBarLandscape(
     timerActions: Actions,
-    onStartStopButtonClick: () -> Unit,
-    onRestartSegmentButtonClick: () -> Unit,
+    onPlayButtonClick: () -> Unit,
+    onBackButtonClick: () -> Unit,
+    onNextButtonClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     Container(
@@ -120,20 +149,22 @@ private fun ActionsBarLandscape(
             .fillMaxHeight()
     ) {
         ConstraintLayout(modifier = Modifier.fillMaxSize()) {
-            val (restartButton, spacer, toggleStartButton) = createRefs()
+            val (backButton, spacer1, spacer2, playButton, nextButton) = createRefs()
             createVerticalChain(
-                restartButton,
-                spacer,
-                toggleStartButton,
+                backButton,
+                spacer1,
+                playButton,
+                spacer2,
+                nextButton,
                 chainStyle = ChainStyle.Packed
             )
 
-            RestartButton(
-                restartButton = timerActions.restart,
-                onClick = onRestartSegmentButtonClick,
-                modifier = Modifier.constrainAs(restartButton) {
+            BackButton(
+                backButton = timerActions.back,
+                onClick = onBackButtonClick,
+                modifier = Modifier.constrainAs(backButton) {
                     top.linkTo(parent.top)
-                    bottom.linkTo(spacer.top)
+                    bottom.linkTo(spacer1.top)
                     start.linkTo(parent.start)
                     end.linkTo(parent.end)
                 }
@@ -142,18 +173,39 @@ private fun ActionsBarLandscape(
                 modifier = Modifier
                     .width(20.dp)
                     .height(20.dp)
-                    .constrainAs(spacer) {
-                        top.linkTo(restartButton.bottom)
-                        bottom.linkTo(toggleStartButton.top)
+                    .constrainAs(spacer1) {
+                        top.linkTo(backButton.bottom)
+                        bottom.linkTo(playButton.top)
                         start.linkTo(parent.start)
                         end.linkTo(parent.end)
                     }
             )
-            ToggleStartButton(
-                toggleStartButton = timerActions.toggleStart,
-                onClick = onStartStopButtonClick,
-                modifier = Modifier.constrainAs(toggleStartButton) {
-                    top.linkTo(spacer.bottom)
+            PlayButton(
+                playButton = timerActions.play,
+                onClick = onPlayButtonClick,
+                modifier = Modifier.constrainAs(playButton) {
+                    top.linkTo(spacer1.bottom)
+                    bottom.linkTo(spacer2.top)
+                    start.linkTo(parent.start)
+                    end.linkTo(parent.end)
+                }
+            )
+            Spacer(
+                modifier = Modifier
+                    .width(20.dp)
+                    .height(20.dp)
+                    .constrainAs(spacer2) {
+                        top.linkTo(playButton.bottom)
+                        bottom.linkTo(nextButton.top)
+                        start.linkTo(parent.start)
+                        end.linkTo(parent.end)
+                    }
+            )
+            NextButton(
+                nextButton = timerActions.next,
+                onClick = onNextButtonClick,
+                modifier = Modifier.constrainAs(nextButton) {
+                    top.linkTo(spacer2.bottom)
                     bottom.linkTo(parent.bottom)
                     start.linkTo(parent.start)
                     end.linkTo(parent.end)
@@ -174,31 +226,46 @@ private fun Container(modifier: Modifier = Modifier, content: @Composable BoxSco
 }
 
 @Composable
-private fun RestartButton(
-    restartButton: Actions.Button,
+private fun BackButton(
+    backButton: Actions.Button,
     onClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     TempoIconButton(
         onClick = onClick,
-        iconResId = restartButton.iconResId,
-        modifier = modifier.testTag(ButtonRestartTestTag),
-        contentDescription = stringResource(restartButton.contentDescriptionResId),
-        size = restartButton.size
+        iconResId = backButton.iconResId,
+        modifier = modifier.testTag(ButtonBackTestTag),
+        contentDescription = stringResource(backButton.contentDescriptionResId),
+        size = backButton.size
     )
 }
 
 @Composable
-private fun ToggleStartButton(
-    toggleStartButton: Actions.Button,
+private fun NextButton(
+    nextButton: Actions.Button,
     onClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     TempoIconButton(
         onClick = onClick,
-        iconResId = toggleStartButton.iconResId,
+        iconResId = nextButton.iconResId,
+        modifier = modifier.testTag(ButtonNextTestTag),
+        contentDescription = stringResource(nextButton.contentDescriptionResId),
+        size = nextButton.size
+    )
+}
+
+@Composable
+private fun PlayButton(
+    playButton: Actions.Button,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    TempoIconButton(
+        onClick = onClick,
+        iconResId = playButton.iconResId,
         modifier = modifier.testTag(ButtonToggleStartTestTag),
-        contentDescription = stringResource(toggleStartButton.contentDescriptionResId),
-        size = toggleStartButton.size
+        contentDescription = stringResource(playButton.contentDescriptionResId),
+        size = playButton.size
     )
 }

--- a/features/timer/src/main/java/com/enricog/features/timer/ui_components/TimerCountingScene.kt
+++ b/features/timer/src/main/java/com/enricog/features/timer/ui_components/TimerCountingScene.kt
@@ -44,19 +44,22 @@ internal const val SegmentNameTestTag = "SegmentNameTestTag"
 @Composable
 internal fun TimerCountingScene(
     state: TimerViewState.Counting,
-    onToggleTimer: () -> Unit,
-    onRestartSegment: () -> Unit
+    onPlay: () -> Unit,
+    onBack: () -> Unit,
+    onNext: () -> Unit
 ) {
     when (ScreenConfiguration.orientation) {
         PORTRAIT -> TimerCountingScenePortrait(
             state = state,
-            onToggleTimer = onToggleTimer,
-            onRestartSegment = onRestartSegment
+            onPlay = onPlay,
+            onBack = onBack,
+            onNext = onNext
         )
         LANDSCAPE -> TimerCountingSceneLandscape(
             state = state,
-            onToggleTimer = onToggleTimer,
-            onRestartSegment = onRestartSegment
+            onPlay = onPlay,
+            onBack = onBack,
+            onNext = onNext
         )
     }
 }
@@ -64,8 +67,9 @@ internal fun TimerCountingScene(
 @Composable
 private fun TimerCountingScenePortrait(
     state: TimerViewState.Counting,
-    onToggleTimer: () -> Unit,
-    onRestartSegment: () -> Unit
+    onPlay: () -> Unit,
+    onBack: () -> Unit,
+    onNext: () -> Unit
 ) {
     TimerBackground(clockBackgroundColor = state.clockBackgroundColor) {
         ConstraintLayout(
@@ -100,8 +104,9 @@ private fun TimerCountingScenePortrait(
             )
             ActionsBar(
                 timerActions = state.timerActions,
-                onStartStopButtonClick = onToggleTimer,
-                onRestartSegmentButtonClick = onRestartSegment,
+                onPlayButtonClick = onPlay,
+                onBackButtonClick = onBack,
+                onNextButtonClick = onNext,
                 modifier = Modifier.constrainAs(actionBar) {
                     top.linkTo(clock.bottom)
                     bottom.linkTo(parent.bottom)
@@ -116,8 +121,9 @@ private fun TimerCountingScenePortrait(
 @Composable
 private fun TimerCountingSceneLandscape(
     state: TimerViewState.Counting,
-    onToggleTimer: () -> Unit,
-    onRestartSegment: () -> Unit
+    onPlay: () -> Unit,
+    onBack: () -> Unit,
+    onNext: () -> Unit
 ) {
     TimerBackground(clockBackgroundColor = state.clockBackgroundColor) {
         ConstraintLayout(
@@ -151,8 +157,9 @@ private fun TimerCountingSceneLandscape(
             )
             ActionsBar(
                 timerActions = state.timerActions,
-                onStartStopButtonClick = onToggleTimer,
-                onRestartSegmentButtonClick = onRestartSegment,
+                onPlayButtonClick = onPlay,
+                onBackButtonClick = onBack,
+                onNextButtonClick = onNext,
                 modifier = Modifier.constrainAs(actionBar) {
                     top.linkTo(parent.top)
                     bottom.linkTo(parent.bottom)

--- a/features/timer/src/main/res/drawable/ic_timer_next.xml
+++ b/features/timer/src/main/res/drawable/ic_timer_next.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="12dp"
+    android:height="12dp"
+    android:viewportWidth="12"
+    android:viewportHeight="12">
+  <path
+      android:pathData="M0.219,10.845A2.082,2.082 135,0 0,3.012 11.781L9.531,8.521L9.531,10.766A1.235,1.235 0,0 0,12 10.766l-0,-9.532a1.235,1.235 0,0 0,-2.469 -0L9.531,3.48l-6.519,-3.26A2.081,2.081 0,0 0,0 2.082L0,9.919A2.068,2.068 0,0 0,0.219 10.845Z"
+      android:fillColor="#fff"/>
+</vector>

--- a/features/timer/src/main/res/values/strings.xml
+++ b/features/timer/src/main/res/values/strings.xml
@@ -15,8 +15,8 @@
 
     <string name="content_description_button_reset_routine">Restart routine</string>
     <string name="content_description_button_done_routine">Routine completed, exit</string>
-    <string name="content_description_button_back_routine_segment">Previous segment</string>
-    <string name="content_description_button_next_routine_segment">Next segment</string>
+    <string name="content_description_button_back_routine_segment">Previous step</string>
+    <string name="content_description_button_next_routine_segment">Next step</string>
     <string name="content_description_button_stop_routine_segment">Stop counting</string>
     <string name="content_description_button_start_routine_segment">Start counting</string>
     <string name="content_description_dialog_quite_routine_button_positive">Yes, quit routine</string>

--- a/features/timer/src/main/res/values/strings.xml
+++ b/features/timer/src/main/res/values/strings.xml
@@ -15,7 +15,8 @@
 
     <string name="content_description_button_reset_routine">Restart routine</string>
     <string name="content_description_button_done_routine">Routine completed, exit</string>
-    <string name="content_description_button_restart_routine_segment">Restart counting</string>
+    <string name="content_description_button_back_routine_segment">Previous segment</string>
+    <string name="content_description_button_next_routine_segment">Next segment</string>
     <string name="content_description_button_stop_routine_segment">Stop counting</string>
     <string name="content_description_button_start_routine_segment">Start counting</string>
     <string name="content_description_dialog_quite_routine_button_positive">Yes, quit routine</string>

--- a/features/timer/src/test/java/com/enricog/features/timer/TimerReducerTest.kt
+++ b/features/timer/src/test/java/com/enricog/features/timer/TimerReducerTest.kt
@@ -4,7 +4,6 @@ import com.enricog.data.routines.api.entities.Routine
 import com.enricog.data.routines.api.entities.Segment
 import com.enricog.data.routines.api.entities.TimeType
 import com.enricog.data.routines.testing.entities.EMPTY
-import com.enricog.entities.asID
 import com.enricog.entities.seconds
 import com.enricog.features.timer.models.Count
 import com.enricog.features.timer.models.SegmentStep
@@ -15,50 +14,161 @@ import kotlin.test.assertEquals
 
 class TimerReducerTest {
 
-    private val sut = TimerReducer()
+    private val timerReducer = TimerReducer()
 
     @Test
     fun `should setup state with starting segment when start timer offset is more than 0`() {
-        val segment = Segment.EMPTY.copy(time = 5.seconds)
         val routine = Routine.EMPTY.copy(
-            startTimeOffset = 10.seconds,
-            segments = listOf(segment)
+            startTimeOffset = 5.seconds,
+            segments = listOf(
+                Segment.EMPTY.copy(name = "segment name stopwatch", type = TimeType.STOPWATCH),
+                Segment.EMPTY.copy(
+                    name = "segment name rest",
+                    type = TimeType.REST,
+                    time = 4.seconds
+                ),
+                Segment.EMPTY.copy(
+                    name = "segment name timer",
+                    type = TimeType.TIMER,
+                    time = 10.seconds
+                )
+            )
         )
         val state = TimerState.Idle
         val expected = TimerState.Counting(
             routine = routine,
-            runningSegment = segment,
-            step = SegmentStep(
-                count = Count.idle(seconds = 10.seconds),
-                type = SegmentStepType.STARTING
+            runningStep = SegmentStep(
+                id = 0,
+                count = Count(seconds = 5.seconds, isRunning = false, isCompleted = false),
+                type = SegmentStepType.STARTING,
+                segment = Segment.EMPTY.copy(
+                    name = "segment name stopwatch",
+                    type = TimeType.STOPWATCH
+                )
+            ),
+            steps = listOf(
+                SegmentStep(
+                    id = 0,
+                    count = Count.idle(seconds = 5.seconds),
+                    type = SegmentStepType.STARTING,
+                    segment = Segment.EMPTY.copy(
+                        name = "segment name stopwatch",
+                        type = TimeType.STOPWATCH
+                    )
+                ),
+                SegmentStep(
+                    id = 1,
+                    count = Count.idle(seconds = 0.seconds),
+                    type = SegmentStepType.IN_PROGRESS,
+                    segment = Segment.EMPTY.copy(
+                        name = "segment name stopwatch",
+                        type = TimeType.STOPWATCH
+                    )
+                ),
+                SegmentStep(
+                    id = 2,
+                    count = Count.idle(seconds = 4.seconds),
+                    type = SegmentStepType.IN_PROGRESS,
+                    segment = Segment.EMPTY.copy(
+                        name = "segment name rest",
+                        type = TimeType.REST,
+                        time = 4.seconds
+                    )
+                ),
+                SegmentStep(
+                    id = 3,
+                    count = Count.idle(seconds = 5.seconds),
+                    type = SegmentStepType.STARTING,
+                    segment = Segment.EMPTY.copy(
+                        name = "segment name timer",
+                        type = TimeType.TIMER,
+                        time = 10.seconds
+                    )
+                ),
+                SegmentStep(
+                    id = 4,
+                    count = Count.idle(seconds = 10.seconds),
+                    type = SegmentStepType.IN_PROGRESS,
+                    segment = Segment.EMPTY.copy(
+                        name = "segment name timer",
+                        type = TimeType.TIMER,
+                        time = 10.seconds
+                    )
+                )
             ),
             isSoundEnabled = true
         )
 
-        val actual = sut.setup(state = state, routine = routine)
+        val actual = timerReducer.setup(state = state, routine = routine)
 
         assertEquals(expected, actual)
     }
 
     @Test
     fun `should setup state with segment in progress when start timer offset is 0`() {
-        val segment = Segment.EMPTY.copy(time = 5.seconds)
         val routine = Routine.EMPTY.copy(
             startTimeOffset = 0.seconds,
-            segments = listOf(segment)
+            segments = listOf(
+                Segment.EMPTY.copy(name = "segment name stopwatch", type = TimeType.STOPWATCH),
+                Segment.EMPTY.copy(
+                    name = "segment name rest",
+                    type = TimeType.REST,
+                    time = 4.seconds
+                ),
+                Segment.EMPTY.copy(
+                    name = "segment name timer",
+                    type = TimeType.TIMER,
+                    time = 10.seconds
+                )
+            )
         )
         val state = TimerState.Idle
         val expected = TimerState.Counting(
             routine = routine,
-            runningSegment = segment,
-            step = SegmentStep(
-                count = Count.idle(seconds = 5.seconds),
-                type = SegmentStepType.IN_PROGRESS
+            runningStep = SegmentStep(
+                id = 0,
+                count = Count(seconds = 0.seconds, isRunning = false, isCompleted = false),
+                type = SegmentStepType.IN_PROGRESS,
+                segment = Segment.EMPTY.copy(
+                    name = "segment name stopwatch",
+                    type = TimeType.STOPWATCH
+                )
+            ),
+            steps = listOf(
+                SegmentStep(
+                    id = 0,
+                    count = Count.idle(seconds = 0.seconds),
+                    type = SegmentStepType.IN_PROGRESS,
+                    segment = Segment.EMPTY.copy(
+                        name = "segment name stopwatch",
+                        type = TimeType.STOPWATCH
+                    )
+                ),
+                SegmentStep(
+                    id = 1,
+                    count = Count.idle(seconds = 4.seconds),
+                    type = SegmentStepType.IN_PROGRESS,
+                    segment = Segment.EMPTY.copy(
+                        name = "segment name rest",
+                        type = TimeType.REST,
+                        time = 4.seconds
+                    )
+                ),
+                SegmentStep(
+                    id = 2,
+                    count = Count.idle(seconds = 10.seconds),
+                    type = SegmentStepType.IN_PROGRESS,
+                    segment = Segment.EMPTY.copy(
+                        name = "segment name timer",
+                        type = TimeType.TIMER,
+                        time = 10.seconds
+                    )
+                )
             ),
             isSoundEnabled = true
         )
 
-        val actual = sut.setup(state = state, routine = routine)
+        val actual = timerReducer.setup(state = state, routine = routine)
 
         assertEquals(expected, actual)
     }
@@ -67,29 +177,47 @@ class TimerReducerTest {
     fun `should setup state with same sound enable status when current state is counting`() {
         val segment = Segment.EMPTY.copy(time = 5.seconds)
         val routine = Routine.EMPTY.copy(
-            startTimeOffset = 10.seconds,
+            startTimeOffset = 0.seconds,
             segments = listOf(segment)
         )
         val state = TimerState.Counting(
             routine = routine,
-            runningSegment = segment,
-            step = SegmentStep(
-                count = Count.start(seconds = 3.seconds),
-                type = SegmentStepType.IN_PROGRESS
+            runningStep = SegmentStep(
+                id = 0,
+                count = Count(seconds = 2.seconds, isRunning = true, isCompleted = false),
+                type = SegmentStepType.IN_PROGRESS,
+                segment = segment
+            ),
+            steps = listOf(
+                SegmentStep(
+                    id = 0,
+                    count = Count.idle(seconds = 5.seconds),
+                    type = SegmentStepType.IN_PROGRESS,
+                    segment = segment
+                )
             ),
             isSoundEnabled = false
         )
         val expected = TimerState.Counting(
             routine = routine,
-            runningSegment = segment,
-            step = SegmentStep(
-                count = Count.idle(seconds = 10.seconds),
-                type = SegmentStepType.STARTING
+            runningStep = SegmentStep(
+                id = 0,
+                count = Count(seconds = 5.seconds, isRunning = false, isCompleted = false),
+                type = SegmentStepType.IN_PROGRESS,
+                segment = segment
+            ),
+            steps = listOf(
+                SegmentStep(
+                    id = 0,
+                    count = Count.idle(seconds = 5.seconds),
+                    type = SegmentStepType.IN_PROGRESS,
+                    segment = segment
+                )
             ),
             isSoundEnabled = false
         )
 
-        val actual = sut.setup(state = state, routine = routine)
+        val actual = timerReducer.setup(state = state, routine = routine)
 
         assertEquals(expected, actual)
     }
@@ -99,7 +227,7 @@ class TimerReducerTest {
         val exception = Exception()
         val expected = TimerState.Error(throwable = exception)
 
-        val actual = sut.error(throwable = exception)
+        val actual = timerReducer.error(throwable = exception)
 
         assertEquals(expected, actual)
     }
@@ -107,20 +235,27 @@ class TimerReducerTest {
     @Test
     fun `should return same state on progressing time when count is not running`() {
         val segment = Segment.EMPTY.copy(time = 10.seconds, type = TimeType.TIMER)
-        val routine = Routine.EMPTY.copy(
-            segments = listOf(segment)
-        )
+        val routine = Routine.EMPTY.copy(segments = listOf(segment))
         val state = TimerState.Counting(
             routine = routine,
-            runningSegment = segment,
-            step = SegmentStep(
+            runningStep = SegmentStep(
+                id = 0,
                 count = Count(seconds = 10.seconds, isRunning = false, isCompleted = false),
-                type = SegmentStepType.IN_PROGRESS
+                type = SegmentStepType.IN_PROGRESS,
+                segment = segment
+            ),
+            steps = listOf(
+                SegmentStep(
+                    id = 0,
+                    count = Count.idle(seconds = 10.seconds),
+                    type = SegmentStepType.IN_PROGRESS,
+                    segment = segment
+                )
             ),
             isSoundEnabled = true
         )
 
-        val actual = sut.progressTime(state)
+        val actual = timerReducer.progressTime(state)
 
         assertEquals(state, actual)
     }
@@ -128,185 +263,287 @@ class TimerReducerTest {
     @Test
     fun `should update state progressing the time when count is running`() {
         val segment = Segment.EMPTY.copy(time = 10.seconds, type = TimeType.TIMER)
-        val routine = Routine.EMPTY.copy(
-            segments = listOf(segment)
-        )
+        val routine = Routine.EMPTY.copy(segments = listOf(segment))
         val state = TimerState.Counting(
             routine = routine,
-            runningSegment = segment,
-            step = SegmentStep(
+            runningStep = SegmentStep(
+                id = 0,
                 count = Count(seconds = 10.seconds, isRunning = true, isCompleted = false),
-                type = SegmentStepType.IN_PROGRESS
+                type = SegmentStepType.IN_PROGRESS,
+                segment = segment
+            ),
+            steps = listOf(
+                SegmentStep(
+                    id = 0,
+                    count = Count.idle(seconds = 10.seconds),
+                    type = SegmentStepType.IN_PROGRESS,
+                    segment = segment
+                )
             ),
             isSoundEnabled = true
         )
         val expected = TimerState.Counting(
             routine = routine,
-            runningSegment = segment,
-            step = SegmentStep(
+            runningStep = SegmentStep(
+                id = 0,
                 count = Count(seconds = 9.seconds, isRunning = true, isCompleted = false),
-                type = SegmentStepType.IN_PROGRESS
+                type = SegmentStepType.IN_PROGRESS,
+                segment = segment
+            ),
+            steps = listOf(
+                SegmentStep(
+                    id = 0,
+                    count = Count.idle(seconds = 10.seconds),
+                    type = SegmentStepType.IN_PROGRESS,
+                    segment = segment
+                )
             ),
             isSoundEnabled = true
         )
 
-        val actual = sut.progressTime(state)
+        val actual = timerReducer.progressTime(state)
 
         assertEquals(expected, actual)
     }
 
     @Test
     fun `should update state progressing time by counting down when running a starting segment`() {
+        val segment = Segment.EMPTY.copy(type = TimeType.STOPWATCH, time = 0.seconds)
+        val routine = Routine.EMPTY.copy(segments = listOf(segment))
         val state = TimerState.Counting(
-            routine = Routine.EMPTY,
-            runningSegment = Segment.EMPTY.copy(type = TimeType.STOPWATCH, time = 0.seconds),
-            step = SegmentStep(
-                count = Count.start(seconds = 10.seconds),
-                type = SegmentStepType.STARTING
+            routine = routine,
+            runningStep = SegmentStep(
+                id = 0,
+                count = Count(seconds = 10.seconds, isRunning = true, isCompleted = false),
+                type = SegmentStepType.STARTING,
+                segment = segment
+            ),
+            steps = listOf(
+                SegmentStep(
+                    id = 0,
+                    count = Count.idle(seconds = 10.seconds),
+                    type = SegmentStepType.IN_PROGRESS,
+                    segment = segment
+                )
             ),
             isSoundEnabled = true
         )
         val expected = TimerState.Counting(
-            routine = Routine.EMPTY,
-            runningSegment = Segment.EMPTY.copy(type = TimeType.STOPWATCH, time = 0.seconds),
-            step = SegmentStep(
-                count = Count.start(seconds = 9.seconds),
-                type = SegmentStepType.STARTING
+            routine = routine,
+            runningStep = SegmentStep(
+                id = 0,
+                count = Count(seconds = 9.seconds, isRunning = true, isCompleted = false),
+                type = SegmentStepType.STARTING,
+                segment = segment
+            ),
+            steps = listOf(
+                SegmentStep(
+                    id = 0,
+                    count = Count.idle(seconds = 10.seconds),
+                    type = SegmentStepType.IN_PROGRESS,
+                    segment = segment
+                )
             ),
             isSoundEnabled = true
         )
 
-        val actual = sut.progressTime(state)
-
-        assertEquals(expected, actual)
-    }
-
-    @Test
-    fun `should update state by progressing the time base on the segment type defined progress`() {
-        val state = TimerState.Counting(
-            routine = Routine.EMPTY,
-            runningSegment = Segment.EMPTY.copy(type = TimeType.STOPWATCH, time = 0.seconds),
-            step = SegmentStep(
-                count = Count.start(seconds = 10.seconds),
-                type = SegmentStepType.IN_PROGRESS
-            ),
-            isSoundEnabled = true
-        )
-        val expected = TimerState.Counting(
-            routine = Routine.EMPTY,
-            runningSegment = Segment.EMPTY.copy(type = TimeType.STOPWATCH, time = 0.seconds),
-            step = SegmentStep(
-                count = Count.start(seconds = 11.seconds),
-                type = SegmentStepType.IN_PROGRESS
-            ),
-            isSoundEnabled = true
-        )
-
-        val actual = sut.progressTime(state)
+        val actual = timerReducer.progressTime(state)
 
         assertEquals(expected, actual)
     }
 
     @Test
     fun `should update state by completing the step on progressing time when a starting segment is running and count reach zero`() {
+        val segment = Segment.EMPTY.copy(type = TimeType.TIMER, time = 10.seconds)
+        val routine = Routine.EMPTY.copy(segments = listOf(segment), startTimeOffset = 5.seconds)
         val state = TimerState.Counting(
-            routine = Routine.EMPTY,
-            runningSegment = Segment.EMPTY.copy(type = TimeType.TIMER, time = 10.seconds),
-            step = SegmentStep(
-                count = Count.start(seconds = 1.seconds),
-                type = SegmentStepType.STARTING
+            routine = routine,
+            runningStep = SegmentStep(
+                id = 0,
+                count = Count(seconds = 1.seconds, isRunning = true, isCompleted = false),
+                type = SegmentStepType.STARTING,
+                segment = segment
+            ),
+            steps = listOf(
+                SegmentStep(
+                    id = 0,
+                    count = Count.idle(seconds = 5.seconds),
+                    type = SegmentStepType.STARTING,
+                    segment = segment
+                ),
+                SegmentStep(
+                    id = 1,
+                    count = Count.idle(seconds = 10.seconds),
+                    type = SegmentStepType.IN_PROGRESS,
+                    segment = segment
+                )
             ),
             isSoundEnabled = true
         )
         val expected = TimerState.Counting(
-            routine = Routine.EMPTY,
-            runningSegment = Segment.EMPTY.copy(type = TimeType.TIMER, time = 10.seconds),
-            step = SegmentStep(
+            routine = routine,
+            runningStep = SegmentStep(
+                id = 0,
                 count = Count(seconds = 0.seconds, isRunning = true, isCompleted = true),
-                type = SegmentStepType.STARTING
+                type = SegmentStepType.STARTING,
+                segment = segment
+            ),
+            steps = listOf(
+                SegmentStep(
+                    id = 0,
+                    count = Count.idle(seconds = 5.seconds),
+                    type = SegmentStepType.STARTING,
+                    segment = segment
+                ),
+                SegmentStep(
+                    id = 1,
+                    count = Count.idle(seconds = 10.seconds),
+                    type = SegmentStepType.IN_PROGRESS,
+                    segment = segment
+                )
             ),
             isSoundEnabled = true
         )
 
-        val actual = sut.progressTime(state)
+        val actual = timerReducer.progressTime(state)
 
         assertEquals(expected, actual)
     }
 
     @Test
     fun `should update state by completing the step on progressing time when a timer segment is running and count reach zero`() {
+        val segment = Segment.EMPTY.copy(type = TimeType.TIMER, time = 10.seconds)
+        val routine = Routine.EMPTY.copy(segments = listOf(segment))
         val state = TimerState.Counting(
-            routine = Routine.EMPTY,
-            runningSegment = Segment.EMPTY.copy(type = TimeType.TIMER, time = 10.seconds),
-            step = SegmentStep(
-                count = Count.start(seconds = 1.seconds),
-                type = SegmentStepType.IN_PROGRESS
+            routine = routine,
+            runningStep = SegmentStep(
+                id = 0,
+                count = Count(seconds = 1.seconds, isRunning = true, isCompleted = false),
+                type = SegmentStepType.IN_PROGRESS,
+                segment = segment
+            ),
+            steps = listOf(
+                SegmentStep(
+                    id = 0,
+                    count = Count.idle(seconds = 10.seconds),
+                    type = SegmentStepType.IN_PROGRESS,
+                    segment = segment
+                )
             ),
             isSoundEnabled = true
         )
         val expected = TimerState.Counting(
-            routine = Routine.EMPTY,
-            runningSegment = Segment.EMPTY.copy(type = TimeType.TIMER, time = 10.seconds),
-            step = SegmentStep(
+            routine = routine,
+            runningStep = SegmentStep(
+                id = 0,
                 count = Count(seconds = 0.seconds, isRunning = true, isCompleted = true),
-                type = SegmentStepType.IN_PROGRESS
+                type = SegmentStepType.IN_PROGRESS,
+                segment = segment
+            ),
+            steps = listOf(
+                SegmentStep(
+                    id = 0,
+                    count = Count.idle(seconds = 10.seconds),
+                    type = SegmentStepType.IN_PROGRESS,
+                    segment = segment
+                )
             ),
             isSoundEnabled = true
         )
 
-        val actual = sut.progressTime(state)
+        val actual = timerReducer.progressTime(state)
 
         assertEquals(expected, actual)
     }
 
     @Test
     fun `should update state by completing the step on progressing time when a rest segment is running and count reach zero`() {
+        val segment = Segment.EMPTY.copy(type = TimeType.REST, time = 10.seconds)
+        val routine = Routine.EMPTY.copy(segments = listOf(segment))
         val state = TimerState.Counting(
-            routine = Routine.EMPTY,
-            runningSegment = Segment.EMPTY.copy(type = TimeType.REST, time = 10.seconds),
-            step = SegmentStep(
-                count = Count.start(seconds = 1.seconds),
-                type = SegmentStepType.IN_PROGRESS
+            routine = routine,
+            runningStep = SegmentStep(
+                id = 0,
+                count = Count(seconds = 1.seconds, isRunning = true, isCompleted = false),
+                type = SegmentStepType.IN_PROGRESS,
+                segment = segment
+            ),
+            steps = listOf(
+                SegmentStep(
+                    id = 0,
+                    count = Count.idle(seconds = 10.seconds),
+                    type = SegmentStepType.IN_PROGRESS,
+                    segment = segment
+                )
             ),
             isSoundEnabled = true
         )
         val expected = TimerState.Counting(
-            routine = Routine.EMPTY,
-            runningSegment = Segment.EMPTY.copy(type = TimeType.REST, time = 10.seconds),
-            step = SegmentStep(
+            routine = routine,
+            runningStep = SegmentStep(
+                id = 0,
                 count = Count(seconds = 0.seconds, isRunning = true, isCompleted = true),
-                type = SegmentStepType.IN_PROGRESS
+                type = SegmentStepType.IN_PROGRESS,
+                segment = segment
+            ),
+            steps = listOf(
+                SegmentStep(
+                    id = 0,
+                    count = Count.idle(seconds = 10.seconds),
+                    type = SegmentStepType.IN_PROGRESS,
+                    segment = segment
+                )
             ),
             isSoundEnabled = true
         )
 
-        val actual = sut.progressTime(state)
+        val actual = timerReducer.progressTime(state)
 
         assertEquals(expected, actual)
     }
 
     @Test
     fun `should update state by increasing the step count on progressing time when a stopwatch segment is running and count is zero`() {
+        val segment = Segment.EMPTY.copy(type = TimeType.STOPWATCH, time = 0.seconds)
+        val routine = Routine.EMPTY.copy(segments = listOf(segment))
         val state = TimerState.Counting(
-            routine = Routine.EMPTY,
-            runningSegment = Segment.EMPTY.copy(type = TimeType.STOPWATCH, time = 1.seconds),
-            step = SegmentStep(
-                count = Count.start(seconds = 0.seconds),
-                type = SegmentStepType.IN_PROGRESS
+            routine = routine,
+            runningStep = SegmentStep(
+                id = 0,
+                count = Count(seconds = 0.seconds, isRunning = true, isCompleted = false),
+                type = SegmentStepType.IN_PROGRESS,
+                segment = segment
+            ),
+            steps = listOf(
+                SegmentStep(
+                    id = 0,
+                    count = Count.idle(seconds = 0.seconds),
+                    type = SegmentStepType.IN_PROGRESS,
+                    segment = segment
+                )
             ),
             isSoundEnabled = true
         )
         val expected = TimerState.Counting(
-            routine = Routine.EMPTY,
-            runningSegment = Segment.EMPTY.copy(type = TimeType.STOPWATCH, time = 1.seconds),
-            step = SegmentStep(
+            routine = routine,
+            runningStep = SegmentStep(
+                id = 0,
                 count = Count(seconds = 1.seconds, isRunning = true, isCompleted = false),
-                type = SegmentStepType.IN_PROGRESS
+                type = SegmentStepType.IN_PROGRESS,
+                segment = segment
+            ),
+            steps = listOf(
+                SegmentStep(
+                    id = 0,
+                    count = Count.idle(seconds = 0.seconds),
+                    type = SegmentStepType.IN_PROGRESS,
+                    segment = segment
+                )
             ),
             isSoundEnabled = true
         )
 
-        val actual = sut.progressTime(state)
+        val actual = timerReducer.progressTime(state)
 
         assertEquals(expected, actual)
     }
@@ -314,20 +551,27 @@ class TimerReducerTest {
     @Test
     fun `should return same state on toggling the timer when the count is completed`() {
         val segment = Segment.EMPTY.copy(time = 10.seconds, type = TimeType.TIMER)
-        val routine = Routine.EMPTY.copy(
-            segments = listOf(segment)
-        )
+        val routine = Routine.EMPTY.copy(segments = listOf(segment))
         val state = TimerState.Counting(
             routine = routine,
-            runningSegment = segment,
-            step = SegmentStep(
+            runningStep = SegmentStep(
+                id = 0,
                 count = Count(seconds = 10.seconds, isRunning = true, isCompleted = true),
-                type = SegmentStepType.IN_PROGRESS
+                type = SegmentStepType.IN_PROGRESS,
+                segment = segment
+            ),
+            steps = listOf(
+                SegmentStep(
+                    id = 0,
+                    count = Count.idle(seconds = 10.seconds),
+                    type = SegmentStepType.IN_PROGRESS,
+                    segment = segment
+                )
             ),
             isSoundEnabled = true
         )
 
-        val actual = sut.toggleTimeRunning(state)
+        val actual = timerReducer.toggleTimeRunning(state)
 
         assertEquals(state, actual)
     }
@@ -335,29 +579,45 @@ class TimerReducerTest {
     @Test
     fun `should update the state with completed count on toggling the timer when stopwatch segment is running`() {
         val segment = Segment.EMPTY.copy(time = 10.seconds, type = TimeType.STOPWATCH)
-        val routine = Routine.EMPTY.copy(
-            segments = listOf(segment)
-        )
+        val routine = Routine.EMPTY.copy(segments = listOf(segment))
         val state = TimerState.Counting(
             routine = routine,
-            runningSegment = segment,
-            step = SegmentStep(
+            runningStep = SegmentStep(
+                id = 0,
                 count = Count(seconds = 10.seconds, isRunning = true, isCompleted = false),
-                type = SegmentStepType.IN_PROGRESS
+                type = SegmentStepType.IN_PROGRESS,
+                segment = segment
+            ),
+            steps = listOf(
+                SegmentStep(
+                    id = 0,
+                    count = Count.idle(seconds = 10.seconds),
+                    type = SegmentStepType.IN_PROGRESS,
+                    segment = segment
+                )
             ),
             isSoundEnabled = true
         )
         val expected = TimerState.Counting(
             routine = routine,
-            runningSegment = segment,
-            step = SegmentStep(
+            runningStep = SegmentStep(
+                id = 0,
                 count = Count(seconds = 10.seconds, isRunning = true, isCompleted = true),
-                type = SegmentStepType.IN_PROGRESS
+                type = SegmentStepType.IN_PROGRESS,
+                segment = segment
+            ),
+            steps = listOf(
+                SegmentStep(
+                    id = 0,
+                    count = Count.idle(seconds = 10.seconds),
+                    type = SegmentStepType.IN_PROGRESS,
+                    segment = segment
+                )
             ),
             isSoundEnabled = true
         )
 
-        val actual = sut.toggleTimeRunning(state)
+        val actual = timerReducer.toggleTimeRunning(state)
 
         assertEquals(expected, actual)
     }
@@ -365,85 +625,265 @@ class TimerReducerTest {
     @Test
     fun `should update state with count not running on toggle timer when a not stopwatch segment count is not completed and running`() {
         val segment = Segment.EMPTY.copy(time = 10.seconds, type = TimeType.TIMER)
-        val routine = Routine.EMPTY.copy(
-            segments = listOf(segment)
-        )
+        val routine = Routine.EMPTY.copy(segments = listOf(segment))
         val state = TimerState.Counting(
             routine = routine,
-            runningSegment = segment,
-            step = SegmentStep(
+            runningStep = SegmentStep(
+                id = 0,
                 count = Count(seconds = 10.seconds, isRunning = true, isCompleted = false),
-                type = SegmentStepType.IN_PROGRESS
+                type = SegmentStepType.IN_PROGRESS,
+                segment = segment
+            ),
+            steps = listOf(
+                SegmentStep(
+                    id = 0,
+                    count = Count.idle(seconds = 10.seconds),
+                    type = SegmentStepType.IN_PROGRESS,
+                    segment = segment
+                )
             ),
             isSoundEnabled = true
         )
         val expected = TimerState.Counting(
             routine = routine,
-            runningSegment = segment,
-            step = SegmentStep(
+            runningStep = SegmentStep(
+                id = 0,
                 count = Count(seconds = 10.seconds, isRunning = false, isCompleted = false),
-                type = SegmentStepType.IN_PROGRESS
+                type = SegmentStepType.IN_PROGRESS,
+                segment = segment
+            ),
+            steps = listOf(
+                SegmentStep(
+                    id = 0,
+                    count = Count.idle(seconds = 10.seconds),
+                    type = SegmentStepType.IN_PROGRESS,
+                    segment = segment
+                )
             ),
             isSoundEnabled = true
         )
 
-        val actual = sut.toggleTimeRunning(state)
+        val actual = timerReducer.toggleTimeRunning(state)
 
         assertEquals(expected, actual)
     }
 
     @Test
-    fun `should update state with reset second count on reset timer when a segment is running`() {
+    fun `should update state resetting the step count on jump step back when a step count is not in the inital value`() {
         val segment = Segment.EMPTY.copy(time = 10.seconds, type = TimeType.TIMER)
-        val routine = Routine.EMPTY.copy(
-            segments = listOf(segment)
-        )
+        val routine = Routine.EMPTY.copy(segments = listOf(segment))
         val state = TimerState.Counting(
             routine = routine,
-            runningSegment = segment,
-            step = SegmentStep(
+            runningStep = SegmentStep(
+                id = 0,
                 count = Count(seconds = 5.seconds, isRunning = true, isCompleted = false),
-                type = SegmentStepType.IN_PROGRESS
+                type = SegmentStepType.IN_PROGRESS,
+                segment = segment
+            ),
+            steps = listOf(
+                SegmentStep(
+                    id = 0,
+                    count = Count.idle(seconds = 10.seconds),
+                    type = SegmentStepType.IN_PROGRESS,
+                    segment = segment
+                )
             ),
             isSoundEnabled = true
         )
         val expected = TimerState.Counting(
             routine = routine,
-            runningSegment = segment,
-            step = SegmentStep(
+            runningStep = SegmentStep(
+                id = 0,
                 count = Count(seconds = 10.seconds, isRunning = false, isCompleted = false),
-                type = SegmentStepType.IN_PROGRESS
+                type = SegmentStepType.IN_PROGRESS,
+                segment = segment
+            ),
+            steps = listOf(
+                SegmentStep(
+                    id = 0,
+                    count = Count.idle(seconds = 10.seconds),
+                    type = SegmentStepType.IN_PROGRESS,
+                    segment = segment
+                )
             ),
             isSoundEnabled = true
         )
 
-        val actual = sut.timeBack(state)
+        val actual = timerReducer.jumpStepBack(state)
 
         assertEquals(expected, actual)
     }
 
     @Test
-    fun `should update state with reset second count on reset timer when a segment is starting`() {
+    fun `should update state by running the previous step on jump step back when segment count is in the initial value`() {
+        val segment = Segment.EMPTY.copy(time = 10.seconds, type = TimeType.TIMER)
+        val routine = Routine.EMPTY.copy(segments = listOf(segment), startTimeOffset = 5.seconds)
         val state = TimerState.Counting(
-            routine = Routine.EMPTY.copy(startTimeOffset = 10.seconds),
-            runningSegment = Segment.EMPTY.copy(time = 99.seconds),
-            step = SegmentStep(
-                count = Count(seconds = 5.seconds, isRunning = true, isCompleted = false),
-                type = SegmentStepType.STARTING
+            routine = routine,
+            runningStep = SegmentStep(
+                id = 1,
+                count = Count(seconds = 10.seconds, isRunning = true, isCompleted = false),
+                type = SegmentStepType.IN_PROGRESS,
+                segment = segment
+            ),
+            steps = listOf(
+                SegmentStep(
+                    id = 0,
+                    count = Count.idle(seconds = 5.seconds),
+                    type = SegmentStepType.STARTING,
+                    segment = segment
+                ),
+                SegmentStep(
+                    id = 1,
+                    count = Count.idle(seconds = 10.seconds),
+                    type = SegmentStepType.IN_PROGRESS,
+                    segment = segment
+                )
             ),
             isSoundEnabled = true
         )
         val expected = TimerState.Counting(
-            routine = Routine.EMPTY.copy(startTimeOffset = 10.seconds),
-            runningSegment = Segment.EMPTY.copy(time = 99.seconds),
-            step = SegmentStep(
-                count = Count(seconds = 10.seconds, isRunning = false, isCompleted = false),
-                type = SegmentStepType.STARTING
+            routine = routine,
+            runningStep = SegmentStep(
+                id = 0,
+                count = Count(seconds = 5.seconds, isRunning = false, isCompleted = false),
+                type = SegmentStepType.STARTING,
+                segment = segment
+            ),
+            steps = listOf(
+                SegmentStep(
+                    id = 0,
+                    count = Count.idle(seconds = 5.seconds),
+                    type = SegmentStepType.STARTING,
+                    segment = segment
+                ),
+                SegmentStep(
+                    id = 1,
+                    count = Count.idle(seconds = 10.seconds),
+                    type = SegmentStepType.IN_PROGRESS,
+                    segment = segment
+                )
             ),
             isSoundEnabled = true
         )
 
-        val actual = sut.timeBack(state)
+        val actual = timerReducer.jumpStepBack(state)
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should update state by running the next step on jump step next when there is a next step`() {
+        val segment = Segment.EMPTY.copy(time = 10.seconds, type = TimeType.TIMER)
+        val routine = Routine.EMPTY.copy(segments = listOf(segment), startTimeOffset = 5.seconds)
+        val state = TimerState.Counting(
+            routine = routine,
+            runningStep = SegmentStep(
+                id = 0,
+                count = Count(seconds = 5.seconds, isRunning = true, isCompleted = false),
+                type = SegmentStepType.STARTING,
+                segment = segment
+            ),
+            steps = listOf(
+                SegmentStep(
+                    id = 0,
+                    count = Count.idle(seconds = 5.seconds),
+                    type = SegmentStepType.STARTING,
+                    segment = segment
+                ),
+                SegmentStep(
+                    id = 1,
+                    count = Count.idle(seconds = 10.seconds),
+                    type = SegmentStepType.IN_PROGRESS,
+                    segment = segment
+                )
+            ),
+            isSoundEnabled = true
+        )
+        val expected = TimerState.Counting(
+            routine = routine,
+            runningStep = SegmentStep(
+                id = 1,
+                count = Count(seconds = 10.seconds, isRunning = false, isCompleted = false),
+                type = SegmentStepType.IN_PROGRESS,
+                segment = segment
+            ),
+            steps = listOf(
+                SegmentStep(
+                    id = 0,
+                    count = Count.idle(seconds = 5.seconds),
+                    type = SegmentStepType.STARTING,
+                    segment = segment
+                ),
+                SegmentStep(
+                    id = 1,
+                    count = Count.idle(seconds = 10.seconds),
+                    type = SegmentStepType.IN_PROGRESS,
+                    segment = segment
+                )
+            ),
+            isSoundEnabled = true
+        )
+
+        val actual = timerReducer.jumpStepNext(state)
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should update state by setting running step as completed on jump step next when there is not a next step`() {
+        val segment = Segment.EMPTY.copy(time = 10.seconds, type = TimeType.TIMER)
+        val routine = Routine.EMPTY.copy(segments = listOf(segment), startTimeOffset = 5.seconds)
+        val state = TimerState.Counting(
+            routine = routine,
+            runningStep = SegmentStep(
+                id = 1,
+                count = Count(seconds = 10.seconds, isRunning = true, isCompleted = false),
+                type = SegmentStepType.IN_PROGRESS,
+                segment = segment
+            ),
+            steps = listOf(
+                SegmentStep(
+                    id = 0,
+                    count = Count.idle(seconds = 5.seconds),
+                    type = SegmentStepType.STARTING,
+                    segment = segment
+                ),
+                SegmentStep(
+                    id = 1,
+                    count = Count.idle(seconds = 10.seconds),
+                    type = SegmentStepType.IN_PROGRESS,
+                    segment = segment
+                )
+            ),
+            isSoundEnabled = true
+        )
+        val expected = TimerState.Counting(
+            routine = routine,
+            runningStep = SegmentStep(
+                id = 1,
+                count = Count(seconds = 10.seconds, isRunning = true, isCompleted = true),
+                type = SegmentStepType.IN_PROGRESS,
+                segment = segment
+            ),
+            steps = listOf(
+                SegmentStep(
+                    id = 0,
+                    count = Count.idle(seconds = 5.seconds),
+                    type = SegmentStepType.STARTING,
+                    segment = segment
+                ),
+                SegmentStep(
+                    id = 1,
+                    count = Count.idle(seconds = 10.seconds),
+                    type = SegmentStepType.IN_PROGRESS,
+                    segment = segment
+                )
+            ),
+            isSoundEnabled = true
+        )
+
+        val actual = timerReducer.jumpStepNext(state)
 
         assertEquals(expected, actual)
     }
@@ -451,20 +891,27 @@ class TimerReducerTest {
     @Test
     fun `should return the same state on next step when last segment is running`() {
         val segment = Segment.EMPTY.copy(time = 10.seconds, type = TimeType.TIMER)
-        val routine = Routine.EMPTY.copy(
-            segments = listOf(segment)
-        )
+        val routine = Routine.EMPTY.copy(segments = listOf(segment))
         val state = TimerState.Counting(
             routine = routine,
-            runningSegment = segment,
-            step = SegmentStep(
+            runningStep = SegmentStep(
+                id = 0,
                 count = Count(seconds = 0.seconds, isRunning = false, isCompleted = false),
-                type = SegmentStepType.IN_PROGRESS
+                type = SegmentStepType.IN_PROGRESS,
+                segment = segment
+            ),
+            steps = listOf(
+                SegmentStep(
+                    id = 0,
+                    count = Count.idle(seconds = 10.seconds),
+                    type = SegmentStepType.IN_PROGRESS,
+                    segment = segment
+                )
             ),
             isSoundEnabled = true
         )
 
-        val actual = sut.nextStep(state)
+        val actual = timerReducer.nextStep(state)
 
         assertEquals(state, actual)
     }
@@ -472,30 +919,57 @@ class TimerReducerTest {
     @Test
     fun `should update state with new segment on next step`() {
         val segment = Segment.EMPTY.copy(time = 10.seconds, type = TimeType.TIMER)
-        val routine = Routine.EMPTY.copy(
-            startTimeOffset = 5.seconds,
-            segments = listOf(Segment.EMPTY, segment)
-        )
+        val routine = Routine.EMPTY.copy(segments = listOf(segment), startTimeOffset = 5.seconds)
         val state = TimerState.Counting(
             routine = routine,
-            runningSegment = Segment.EMPTY,
-            step = SegmentStep(
-                count = Count(seconds = 0.seconds, isRunning = false, isCompleted = true),
-                type = SegmentStepType.IN_PROGRESS
+            runningStep = SegmentStep(
+                id = 0,
+                count = Count(seconds = 0.seconds, isRunning = true, isCompleted = true),
+                type = SegmentStepType.STARTING,
+                segment = segment
+            ),
+            steps = listOf(
+                SegmentStep(
+                    id = 0,
+                    count = Count.idle(seconds = 5.seconds),
+                    type = SegmentStepType.STARTING,
+                    segment = segment
+                ),
+                SegmentStep(
+                    id = 1,
+                    count = Count.idle(seconds = 10.seconds),
+                    type = SegmentStepType.IN_PROGRESS,
+                    segment = segment
+                )
             ),
             isSoundEnabled = true
         )
         val expected = TimerState.Counting(
             routine = routine,
-            runningSegment = segment,
-            step = SegmentStep(
-                count = Count(seconds = 5.seconds, isRunning = true, isCompleted = false),
-                type = SegmentStepType.STARTING
+            runningStep = SegmentStep(
+                id = 1,
+                count = Count(seconds = 10.seconds, isRunning = true, isCompleted = false),
+                type = SegmentStepType.IN_PROGRESS,
+                segment = segment
+            ),
+            steps = listOf(
+                SegmentStep(
+                    id = 0,
+                    count = Count.idle(seconds = 5.seconds),
+                    type = SegmentStepType.STARTING,
+                    segment = segment
+                ),
+                SegmentStep(
+                    id = 1,
+                    count = Count.idle(seconds = 10.seconds),
+                    type = SegmentStepType.IN_PROGRESS,
+                    segment = segment
+                )
             ),
             isSoundEnabled = true
         )
 
-        val actual = sut.nextStep(state)
+        val actual = timerReducer.nextStep(state)
 
         assertEquals(expected, actual)
     }
@@ -503,158 +977,73 @@ class TimerReducerTest {
     @Test
     fun `should return the same state on next step when routine is completed`() {
         val segment = Segment.EMPTY.copy(time = 10.seconds, type = TimeType.TIMER)
-        val routine = Routine.EMPTY.copy(
-            segments = listOf(segment)
-        )
+        val routine = Routine.EMPTY.copy(segments = listOf(segment))
         val state = TimerState.Counting(
             routine = routine,
-            runningSegment = segment,
-            step = SegmentStep(
+            runningStep = SegmentStep(
+                id = 0,
                 count = Count(seconds = 0.seconds, isRunning = false, isCompleted = true),
-                type = SegmentStepType.IN_PROGRESS
+                type = SegmentStepType.IN_PROGRESS,
+                segment = segment
+            ),
+            steps = listOf(
+                SegmentStep(
+                    id = 0,
+                    count = Count.idle(seconds = 10.seconds),
+                    type = SegmentStepType.IN_PROGRESS,
+                    segment = segment
+                )
             ),
             isSoundEnabled = true
         )
 
-        val actual = sut.nextStep(state)
+        val actual = timerReducer.nextStep(state)
 
         assertEquals(state, actual)
     }
 
     @Test
-    fun `should update state with starting segment on next step when segment starting count is completed`() {
-        val state = TimerState.Counting(
-            routine = Routine.EMPTY,
-            runningSegment = Segment.EMPTY.copy(time = 10.seconds),
-            step = SegmentStep(
-                count = Count(seconds = 0.seconds, isRunning = true, isCompleted = true),
-                type = SegmentStepType.STARTING
-            ),
-            isSoundEnabled = true
-        )
-        val expected = TimerState.Counting(
-            routine = Routine.EMPTY,
-            runningSegment = Segment.EMPTY.copy(time = 10.seconds),
-            step = SegmentStep(
-                count = Count.start(seconds = 10.seconds),
-                type = SegmentStepType.IN_PROGRESS
-            ),
-            isSoundEnabled = true
-        )
-
-        val actual = sut.nextStep(state)
-
-        assertEquals(expected, actual)
-    }
-
-    @Test
-    fun `should update state with next segment starting on next step when current segment is completed`() {
-        val state = TimerState.Counting(
-            routine = Routine.EMPTY.copy(
-                startTimeOffset = 5.seconds,
-                segments = listOf(
-                    Segment.EMPTY.copy(id = 1.asID), Segment.EMPTY.copy(id = 2.asID)
-                )
-            ),
-            runningSegment = Segment.EMPTY.copy(id = 1.asID),
-            step = SegmentStep(
-                count = Count(seconds = 0.seconds, isRunning = true, isCompleted = true),
-                type = SegmentStepType.IN_PROGRESS
-            ),
-            isSoundEnabled = true
-        )
-        val expected = TimerState.Counting(
-            routine = Routine.EMPTY.copy(
-                startTimeOffset = 5.seconds,
-                segments = listOf(
-                    Segment.EMPTY.copy(id = 1.asID), Segment.EMPTY.copy(id = 2.asID)
-                )
-            ),
-            runningSegment = Segment.EMPTY.copy(id = 2.asID),
-            step = SegmentStep(
-                count = Count.start(seconds = 5.seconds),
-                type = SegmentStepType.STARTING
-            ),
-            isSoundEnabled = true
-        )
-
-        val actual = sut.nextStep(state)
-
-        assertEquals(expected, actual)
-    }
-
-    @Test
-    fun `should update state with reset segment (skip starting) on next step when current segment is completed and next segment is a rest`() {
-        val state = TimerState.Counting(
-            routine = Routine.EMPTY.copy(
-                startTimeOffset = 5.seconds,
-                segments = listOf(
-                    Segment.EMPTY.copy(id = 1.asID, time = 10.seconds, type = TimeType.TIMER),
-                    Segment.EMPTY.copy(id = 2.asID, time = 20.seconds, type = TimeType.REST)
-                )
-            ),
-            runningSegment = Segment.EMPTY.copy(
-                id = 1.asID,
-                time = 10.seconds,
-                type = TimeType.TIMER
-            ),
-            step = SegmentStep(
-                count = Count(seconds = 0.seconds, isRunning = true, isCompleted = true),
-                type = SegmentStepType.IN_PROGRESS
-            ),
-            isSoundEnabled = true
-        )
-        val expected = TimerState.Counting(
-            routine = Routine.EMPTY.copy(
-                startTimeOffset = 5.seconds,
-                segments = listOf(
-                    Segment.EMPTY.copy(id = 1.asID, time = 10.seconds, type = TimeType.TIMER),
-                    Segment.EMPTY.copy(id = 2.asID, time = 20.seconds, type = TimeType.REST)
-                )
-            ),
-            runningSegment = Segment.EMPTY.copy(
-                id = 2.asID,
-                time = 20.seconds,
-                type = TimeType.REST
-            ),
-            step = SegmentStep(
-                count = Count.start(seconds = 20.seconds),
-                type = SegmentStepType.IN_PROGRESS
-            ),
-            isSoundEnabled = true
-        )
-
-        val actual = sut.nextStep(state)
-
-        assertEquals(expected, actual)
-    }
-
-    @Test
     fun `should update state with sound disabled on toggling the sound`() {
         val segment = Segment.EMPTY.copy(time = 10.seconds, type = TimeType.TIMER)
-        val routine = Routine.EMPTY.copy(
-            segments = listOf(segment)
-        )
+        val routine = Routine.EMPTY.copy(segments = listOf(segment))
         val state = TimerState.Counting(
             routine = routine,
-            runningSegment = segment,
-            step = SegmentStep(
-                count = Count(seconds = 10.seconds, isRunning = true, isCompleted = true),
-                type = SegmentStepType.IN_PROGRESS
+            runningStep = SegmentStep(
+                id = 0,
+                count = Count(seconds = 10.seconds, isRunning = true, isCompleted = false),
+                type = SegmentStepType.IN_PROGRESS,
+                segment = segment
+            ),
+            steps = listOf(
+                SegmentStep(
+                    id = 0,
+                    count = Count.idle(seconds = 10.seconds),
+                    type = SegmentStepType.IN_PROGRESS,
+                    segment = segment
+                )
             ),
             isSoundEnabled = true
         )
         val expected = TimerState.Counting(
             routine = routine,
-            runningSegment = segment,
-            step = SegmentStep(
-                count = Count(seconds = 10.seconds, isRunning = true, isCompleted = true),
-                type = SegmentStepType.IN_PROGRESS
+            runningStep = SegmentStep(
+                id = 0,
+                count = Count(seconds = 10.seconds, isRunning = true, isCompleted = false),
+                type = SegmentStepType.IN_PROGRESS,
+                segment = segment
+            ),
+            steps = listOf(
+                SegmentStep(
+                    id = 0,
+                    count = Count.idle(seconds = 10.seconds),
+                    type = SegmentStepType.IN_PROGRESS,
+                    segment = segment
+                )
             ),
             isSoundEnabled = false
         )
 
-        val actual = sut.toggleSound(state)
+        val actual = timerReducer.toggleSound(state)
 
         assertEquals(expected, actual)
     }

--- a/features/timer/src/test/java/com/enricog/features/timer/TimerReducerTest.kt
+++ b/features/timer/src/test/java/com/enricog/features/timer/TimerReducerTest.kt
@@ -417,7 +417,7 @@ class TimerReducerTest {
             isSoundEnabled = true
         )
 
-        val actual = sut.restartTime(state)
+        val actual = sut.timeBack(state)
 
         assertEquals(expected, actual)
     }
@@ -443,7 +443,7 @@ class TimerReducerTest {
             isSoundEnabled = true
         )
 
-        val actual = sut.restartTime(state)
+        val actual = sut.timeBack(state)
 
         assertEquals(expected, actual)
     }

--- a/features/timer/src/test/java/com/enricog/features/timer/TimerStateConverterTest.kt
+++ b/features/timer/src/test/java/com/enricog/features/timer/TimerStateConverterTest.kt
@@ -70,12 +70,12 @@ class TimerStateConverterTest {
             ),
             isSoundEnabled = true,
             timerActions = TimerViewState.Counting.Actions(
-                restart = TimerViewState.Counting.Actions.Button(
+                next = TimerViewState.Counting.Actions.Button(
                     iconResId = R.drawable.ic_timer_back,
-                    contentDescriptionResId = R.string.content_description_button_restart_routine_segment,
+                    contentDescriptionResId = R.string.content_description_button_back_routine_segment,
                     size = TempoIconButtonSize.Normal
                 ),
-                toggleStart = TimerViewState.Counting.Actions.Button(
+                play = TimerViewState.Counting.Actions.Button(
                     iconResId =  R.drawable.ic_timer_stop,
                     contentDescriptionResId =  R.string.content_description_button_stop_routine_segment,
                     size = TempoIconButtonSize.Normal
@@ -111,12 +111,12 @@ class TimerStateConverterTest {
             ),
             isSoundEnabled = true,
             timerActions = TimerViewState.Counting.Actions(
-                restart = TimerViewState.Counting.Actions.Button(
+                next = TimerViewState.Counting.Actions.Button(
                     iconResId = R.drawable.ic_timer_back,
-                    contentDescriptionResId = R.string.content_description_button_restart_routine_segment,
+                    contentDescriptionResId = R.string.content_description_button_back_routine_segment,
                     size = TempoIconButtonSize.Normal
                 ),
-                toggleStart = TimerViewState.Counting.Actions.Button(
+                play = TimerViewState.Counting.Actions.Button(
                     iconResId =  R.drawable.ic_timer_play,
                     contentDescriptionResId =  R.string.content_description_button_start_routine_segment,
                     size = TempoIconButtonSize.Normal
@@ -153,12 +153,12 @@ class TimerStateConverterTest {
                 ),
                 isSoundEnabled = true,
                 timerActions = TimerViewState.Counting.Actions(
-                    restart = TimerViewState.Counting.Actions.Button(
+                    next = TimerViewState.Counting.Actions.Button(
                         iconResId = R.drawable.ic_timer_back,
-                        contentDescriptionResId = R.string.content_description_button_restart_routine_segment,
+                        contentDescriptionResId = R.string.content_description_button_back_routine_segment,
                         size = TempoIconButtonSize.Normal
                     ),
-                    toggleStart = TimerViewState.Counting.Actions.Button(
+                    play = TimerViewState.Counting.Actions.Button(
                         iconResId =  R.drawable.ic_timer_stop,
                         contentDescriptionResId =  R.string.content_description_button_stop_routine_segment,
                         size = TempoIconButtonSize.Normal
@@ -195,12 +195,12 @@ class TimerStateConverterTest {
                 ),
                 isSoundEnabled = true,
                 timerActions = TimerViewState.Counting.Actions(
-                    restart = TimerViewState.Counting.Actions.Button(
+                    next = TimerViewState.Counting.Actions.Button(
                         iconResId = R.drawable.ic_timer_back,
-                        contentDescriptionResId = R.string.content_description_button_restart_routine_segment,
+                        contentDescriptionResId = R.string.content_description_button_back_routine_segment,
                         size = TempoIconButtonSize.Normal
                     ),
-                    toggleStart = TimerViewState.Counting.Actions.Button(
+                    play = TimerViewState.Counting.Actions.Button(
                         iconResId =  R.drawable.ic_timer_stop,
                         contentDescriptionResId =  R.string.content_description_button_stop_routine_segment,
                         size = TempoIconButtonSize.Normal
@@ -237,12 +237,12 @@ class TimerStateConverterTest {
                 ),
                 isSoundEnabled = true,
                 timerActions = TimerViewState.Counting.Actions(
-                    restart = TimerViewState.Counting.Actions.Button(
+                    next = TimerViewState.Counting.Actions.Button(
                         iconResId = R.drawable.ic_timer_back,
-                        contentDescriptionResId = R.string.content_description_button_restart_routine_segment,
+                        contentDescriptionResId = R.string.content_description_button_back_routine_segment,
                         size = TempoIconButtonSize.Normal
                     ),
-                    toggleStart = TimerViewState.Counting.Actions.Button(
+                    play = TimerViewState.Counting.Actions.Button(
                         iconResId =  R.drawable.ic_timer_stop,
                         contentDescriptionResId =  R.string.content_description_button_stop_routine_segment,
                         size = TempoIconButtonSize.Large
@@ -282,12 +282,12 @@ class TimerStateConverterTest {
                 ),
                 isSoundEnabled = true,
                 timerActions = TimerViewState.Counting.Actions(
-                    restart = TimerViewState.Counting.Actions.Button(
+                    next = TimerViewState.Counting.Actions.Button(
                         iconResId = R.drawable.ic_timer_back,
-                        contentDescriptionResId = R.string.content_description_button_restart_routine_segment,
+                        contentDescriptionResId = R.string.content_description_button_back_routine_segment,
                         size = TempoIconButtonSize.Normal
                     ),
-                    toggleStart = TimerViewState.Counting.Actions.Button(
+                    play = TimerViewState.Counting.Actions.Button(
                         iconResId =  R.drawable.ic_timer_stop,
                         contentDescriptionResId =  R.string.content_description_button_stop_routine_segment,
                         size = TempoIconButtonSize.Large
@@ -328,12 +328,12 @@ class TimerStateConverterTest {
                 ),
                 isSoundEnabled = true,
                 timerActions = TimerViewState.Counting.Actions(
-                    restart = TimerViewState.Counting.Actions.Button(
+                    next = TimerViewState.Counting.Actions.Button(
                         iconResId = R.drawable.ic_timer_back,
-                        contentDescriptionResId = R.string.content_description_button_restart_routine_segment,
+                        contentDescriptionResId = R.string.content_description_button_back_routine_segment,
                         size = TempoIconButtonSize.Normal
                     ),
-                    toggleStart = TimerViewState.Counting.Actions.Button(
+                    play = TimerViewState.Counting.Actions.Button(
                         iconResId =  R.drawable.ic_timer_stop,
                         contentDescriptionResId =  R.string.content_description_button_stop_routine_segment,
                         size = TempoIconButtonSize.Large

--- a/features/timer/src/test/java/com/enricog/features/timer/TimerStateConverterTest.kt
+++ b/features/timer/src/test/java/com/enricog/features/timer/TimerStateConverterTest.kt
@@ -23,14 +23,14 @@ class TimerStateConverterTest {
     @get:Rule
     val coroutineRule = CoroutineRule()
 
-    private val sut = TimerStateConverter()
+    private val stateConverter = TimerStateConverter()
 
     @Test
     fun `test map idle state`() = coroutineRule {
         val state = TimerState.Idle
         val expected = TimerViewState.Idle
 
-        val actual = sut.convert(state)
+        val actual = stateConverter.convert(state)
 
         assertEquals(expected, actual)
     }
@@ -41,7 +41,7 @@ class TimerStateConverterTest {
         val state = TimerState.Error(throwable = exception)
         val expected = TimerViewState.Error(throwable = exception)
 
-        val actual = sut.convert(state)
+        val actual = stateConverter.convert(state)
 
         assertEquals(expected, actual)
     }
@@ -53,10 +53,19 @@ class TimerStateConverterTest {
             routine =  Routine.EMPTY.copy(
                 segments = listOf(Segment.EMPTY.copy(name = "segment name", type = TimeType.REST))
             ),
-            runningSegment = Segment.EMPTY.copy(name = "segment name", type = TimeType.REST),
-            step = SegmentStep(
+            runningStep = SegmentStep(
+                id = 0,
                 count = Count(seconds = 5.seconds, isRunning = true, isCompleted = false),
-                type = SegmentStepType.IN_PROGRESS
+                type = SegmentStepType.IN_PROGRESS,
+                segment = Segment.EMPTY.copy(name = "segment name", type = TimeType.REST)
+            ),
+            steps = listOf(
+                SegmentStep(
+                    id = 0,
+                    count = Count(seconds = 5.seconds, isRunning = true, isCompleted = false),
+                    type = SegmentStepType.IN_PROGRESS,
+                    segment = Segment.EMPTY.copy(name = "segment name", type = TimeType.REST)
+                )
             ),
             isSoundEnabled = true
         )
@@ -70,7 +79,7 @@ class TimerStateConverterTest {
             ),
             isSoundEnabled = true,
             timerActions = TimerViewState.Counting.Actions(
-                next = TimerViewState.Counting.Actions.Button(
+                back = TimerViewState.Counting.Actions.Button(
                     iconResId = R.drawable.ic_timer_back,
                     contentDescriptionResId = R.string.content_description_button_back_routine_segment,
                     size = TempoIconButtonSize.Normal
@@ -79,11 +88,16 @@ class TimerStateConverterTest {
                     iconResId =  R.drawable.ic_timer_stop,
                     contentDescriptionResId =  R.string.content_description_button_stop_routine_segment,
                     size = TempoIconButtonSize.Normal
+                ),
+                next = TimerViewState.Counting.Actions.Button(
+                    iconResId = R.drawable.ic_timer_next,
+                    contentDescriptionResId = R.string.content_description_button_next_routine_segment,
+                    size = TempoIconButtonSize.Normal
                 )
             )
         )
 
-        val actual = sut.convert(state)
+        val actual = stateConverter.convert(state)
 
         assertEquals(expected, actual)
     }
@@ -94,10 +108,19 @@ class TimerStateConverterTest {
             routine =  Routine.EMPTY.copy(
                 segments = listOf(Segment.EMPTY.copy(name = "segment name", type = TimeType.REST))
             ),
-            runningSegment = Segment.EMPTY.copy(name = "segment name", type = TimeType.REST),
-            step = SegmentStep(
+            runningStep = SegmentStep(
+                id = 0,
                 count = Count(seconds = 5.seconds, isRunning = false, isCompleted = false),
-                type = SegmentStepType.IN_PROGRESS
+                type = SegmentStepType.IN_PROGRESS,
+                segment = Segment.EMPTY.copy(name = "segment name", type = TimeType.REST)
+            ),
+            steps = listOf(
+                SegmentStep(
+                    id = 0,
+                    count = Count(seconds = 5.seconds, isRunning = false, isCompleted = false),
+                    type = SegmentStepType.IN_PROGRESS,
+                    segment = Segment.EMPTY.copy(name = "segment name", type = TimeType.REST)
+                )
             ),
             isSoundEnabled = true
         )
@@ -111,7 +134,7 @@ class TimerStateConverterTest {
             ),
             isSoundEnabled = true,
             timerActions = TimerViewState.Counting.Actions(
-                next = TimerViewState.Counting.Actions.Button(
+                back = TimerViewState.Counting.Actions.Button(
                     iconResId = R.drawable.ic_timer_back,
                     contentDescriptionResId = R.string.content_description_button_back_routine_segment,
                     size = TempoIconButtonSize.Normal
@@ -120,11 +143,16 @@ class TimerStateConverterTest {
                     iconResId =  R.drawable.ic_timer_play,
                     contentDescriptionResId =  R.string.content_description_button_start_routine_segment,
                     size = TempoIconButtonSize.Normal
+                ),
+                next = TimerViewState.Counting.Actions.Button(
+                    iconResId = R.drawable.ic_timer_next,
+                    contentDescriptionResId = R.string.content_description_button_next_routine_segment,
+                    size = TempoIconButtonSize.Normal
                 )
             )
         )
 
-        val actual = sut.convert(state)
+        val actual = stateConverter.convert(state)
 
         assertEquals(expected, actual)
     }
@@ -136,10 +164,19 @@ class TimerStateConverterTest {
                 routine =  Routine.EMPTY.copy(
                     segments = listOf(Segment.EMPTY.copy(name = "segment name", type = TimeType.REST))
                 ),
-                runningSegment = Segment.EMPTY.copy(name = "segment name", type = TimeType.REST),
-                step = SegmentStep(
+                runningStep = SegmentStep(
+                    id = 0,
                     count = Count(seconds = 5.seconds, isRunning = true, isCompleted = false),
-                    type = SegmentStepType.IN_PROGRESS
+                    type = SegmentStepType.IN_PROGRESS,
+                    segment = Segment.EMPTY.copy(name = "segment name", type = TimeType.REST)
+                ),
+                steps = listOf(
+                    SegmentStep(
+                        id = 0,
+                        count = Count(seconds = 5.seconds, isRunning = true, isCompleted = false),
+                        type = SegmentStepType.IN_PROGRESS,
+                        segment = Segment.EMPTY.copy(name = "segment name", type = TimeType.REST)
+                    )
                 ),
                 isSoundEnabled = true
             )
@@ -153,7 +190,7 @@ class TimerStateConverterTest {
                 ),
                 isSoundEnabled = true,
                 timerActions = TimerViewState.Counting.Actions(
-                    next = TimerViewState.Counting.Actions.Button(
+                    back = TimerViewState.Counting.Actions.Button(
                         iconResId = R.drawable.ic_timer_back,
                         contentDescriptionResId = R.string.content_description_button_back_routine_segment,
                         size = TempoIconButtonSize.Normal
@@ -162,11 +199,16 @@ class TimerStateConverterTest {
                         iconResId =  R.drawable.ic_timer_stop,
                         contentDescriptionResId =  R.string.content_description_button_stop_routine_segment,
                         size = TempoIconButtonSize.Normal
+                    ),
+                    next = TimerViewState.Counting.Actions.Button(
+                        iconResId = R.drawable.ic_timer_next,
+                        contentDescriptionResId = R.string.content_description_button_next_routine_segment,
+                        size = TempoIconButtonSize.Normal
                     )
                 )
             )
 
-            val actual = sut.convert(state)
+            val actual = stateConverter.convert(state)
 
             assertEquals(expected, actual)
         }
@@ -178,10 +220,19 @@ class TimerStateConverterTest {
                 routine = Routine.EMPTY.copy(
                     segments = listOf(Segment.EMPTY.copy(name = "segment name", type = TimeType.TIMER))
                 ),
-                runningSegment = Segment.EMPTY.copy(name = "segment name", type = TimeType.TIMER),
-                step = SegmentStep(
+                runningStep = SegmentStep(
+                    id = 0,
                     count = Count(seconds = 5.seconds, isRunning = true, isCompleted = false),
-                    type = SegmentStepType.IN_PROGRESS
+                    type = SegmentStepType.IN_PROGRESS,
+                    segment =Segment.EMPTY.copy(name = "segment name", type = TimeType.TIMER),
+                ),
+                steps = listOf(
+                    SegmentStep(
+                        id = 0,
+                        count = Count(seconds = 5.seconds, isRunning = true, isCompleted = false),
+                        type = SegmentStepType.IN_PROGRESS,
+                        segment =Segment.EMPTY.copy(name = "segment name", type = TimeType.TIMER),
+                    )
                 ),
                 isSoundEnabled = true
             )
@@ -195,7 +246,7 @@ class TimerStateConverterTest {
                 ),
                 isSoundEnabled = true,
                 timerActions = TimerViewState.Counting.Actions(
-                    next = TimerViewState.Counting.Actions.Button(
+                    back = TimerViewState.Counting.Actions.Button(
                         iconResId = R.drawable.ic_timer_back,
                         contentDescriptionResId = R.string.content_description_button_back_routine_segment,
                         size = TempoIconButtonSize.Normal
@@ -204,11 +255,16 @@ class TimerStateConverterTest {
                         iconResId =  R.drawable.ic_timer_stop,
                         contentDescriptionResId =  R.string.content_description_button_stop_routine_segment,
                         size = TempoIconButtonSize.Normal
+                    ),
+                    next = TimerViewState.Counting.Actions.Button(
+                        iconResId = R.drawable.ic_timer_next,
+                        contentDescriptionResId = R.string.content_description_button_next_routine_segment,
+                        size = TempoIconButtonSize.Normal
                     )
                 )
             )
 
-            val actual = sut.convert(state)
+            val actual = stateConverter.convert(state)
 
             assertEquals(expected, actual)
         }
@@ -220,10 +276,19 @@ class TimerStateConverterTest {
                 routine =  Routine.EMPTY.copy(
                     segments = listOf(Segment.EMPTY.copy(name = "segment name", type = TimeType.STOPWATCH))
                 ),
-                runningSegment = Segment.EMPTY.copy(name = "segment name", type = TimeType.STOPWATCH),
-                step = SegmentStep(
+                runningStep = SegmentStep(
+                    id = 0,
                     count = Count(seconds = 5.seconds, isRunning = true, isCompleted = false),
-                    type = SegmentStepType.IN_PROGRESS
+                    type = SegmentStepType.IN_PROGRESS,
+                    segment = Segment.EMPTY.copy(name = "segment name", type = TimeType.STOPWATCH),
+                ),
+                steps = listOf(
+                    SegmentStep(
+                        id = 0,
+                        count = Count(seconds = 0.seconds, isRunning = true, isCompleted = false),
+                        type = SegmentStepType.IN_PROGRESS,
+                        segment = Segment.EMPTY.copy(name = "segment name", type = TimeType.STOPWATCH),
+                    )
                 ),
                 isSoundEnabled = true
             )
@@ -237,7 +302,7 @@ class TimerStateConverterTest {
                 ),
                 isSoundEnabled = true,
                 timerActions = TimerViewState.Counting.Actions(
-                    next = TimerViewState.Counting.Actions.Button(
+                    back = TimerViewState.Counting.Actions.Button(
                         iconResId = R.drawable.ic_timer_back,
                         contentDescriptionResId = R.string.content_description_button_back_routine_segment,
                         size = TempoIconButtonSize.Normal
@@ -246,11 +311,16 @@ class TimerStateConverterTest {
                         iconResId =  R.drawable.ic_timer_stop,
                         contentDescriptionResId =  R.string.content_description_button_stop_routine_segment,
                         size = TempoIconButtonSize.Large
+                    ),
+                    next = TimerViewState.Counting.Actions.Button(
+                        iconResId = R.drawable.ic_timer_next,
+                        contentDescriptionResId = R.string.content_description_button_next_routine_segment,
+                        size = TempoIconButtonSize.Normal
                     )
                 )
             )
 
-            val actual = sut.convert(state)
+            val actual = stateConverter.convert(state)
 
             assertEquals(expected, actual)
         }
@@ -265,10 +335,25 @@ class TimerStateConverterTest {
                         Segment.EMPTY.copy(name = "segment name", type = TimeType.STOPWATCH)
                     )
                 ),
-                runningSegment = Segment.EMPTY.copy(name = "segment name", type = TimeType.STOPWATCH),
-                step = SegmentStep(
+                runningStep = SegmentStep(
+                    id = 0,
                     count = Count(seconds = 5.seconds, isRunning = true, isCompleted = true),
-                    type = SegmentStepType.STARTING
+                    type = SegmentStepType.STARTING,
+                    segment = Segment.EMPTY.copy(name = "segment name", type = TimeType.STOPWATCH)
+                ),
+                steps = listOf(
+                    SegmentStep(
+                        id = 0,
+                        count = Count(seconds = 0.seconds, isRunning = true, isCompleted = true),
+                        type = SegmentStepType.STARTING,
+                        segment = Segment.EMPTY.copy(name = "segment name", type = TimeType.STOPWATCH)
+                    ),
+                    SegmentStep(
+                        id = 1,
+                        count = Count(seconds = 5.seconds, isRunning = false, isCompleted = false),
+                        type = SegmentStepType.IN_PROGRESS,
+                        segment = Segment.EMPTY.copy(name = "segment name", type = TimeType.STOPWATCH)
+                    )
                 ),
                 isSoundEnabled = true
             )
@@ -282,7 +367,7 @@ class TimerStateConverterTest {
                 ),
                 isSoundEnabled = true,
                 timerActions = TimerViewState.Counting.Actions(
-                    next = TimerViewState.Counting.Actions.Button(
+                    back = TimerViewState.Counting.Actions.Button(
                         iconResId = R.drawable.ic_timer_back,
                         contentDescriptionResId = R.string.content_description_button_back_routine_segment,
                         size = TempoIconButtonSize.Normal
@@ -291,11 +376,16 @@ class TimerStateConverterTest {
                         iconResId =  R.drawable.ic_timer_stop,
                         contentDescriptionResId =  R.string.content_description_button_stop_routine_segment,
                         size = TempoIconButtonSize.Large
+                    ),
+                    next = TimerViewState.Counting.Actions.Button(
+                        iconResId = R.drawable.ic_timer_next,
+                        contentDescriptionResId = R.string.content_description_button_next_routine_segment,
+                        size = TempoIconButtonSize.Normal
                     )
                 )
             )
 
-            val actual = sut.convert(state)
+            val actual = stateConverter.convert(state)
 
             assertEquals(expected, actual)
         }
@@ -311,10 +401,37 @@ class TimerStateConverterTest {
                         Segment.EMPTY.copy(name = "segment name timer", type = TimeType.TIMER)
                     )
                 ),
-                runningSegment = Segment.EMPTY.copy(name = "segment name stopwatch", type = TimeType.STOPWATCH),
-                step = SegmentStep(
+                runningStep = SegmentStep(
+                    id = 1,
                     count = Count(seconds = 5.seconds, isRunning = true, isCompleted = true),
-                    type = SegmentStepType.IN_PROGRESS
+                    type = SegmentStepType.IN_PROGRESS,
+                    segment = Segment.EMPTY.copy(name = "segment name stopwatch", type = TimeType.STOPWATCH)
+                ),
+                steps = listOf(
+                    SegmentStep(
+                        id = 0,
+                        count = Count(seconds = 5.seconds, isRunning = false, isCompleted = false),
+                        type = SegmentStepType.STARTING,
+                        segment = Segment.EMPTY.copy(name = "segment name stopwatch", type = TimeType.STOPWATCH)
+                    ),
+                    SegmentStep(
+                        id = 1,
+                        count = Count(seconds = 0.seconds, isRunning = false, isCompleted = false),
+                        type = SegmentStepType.IN_PROGRESS,
+                        segment = Segment.EMPTY.copy(name = "segment name stopwatch", type = TimeType.STOPWATCH)
+                    ),
+                    SegmentStep(
+                        id = 2,
+                        count = Count(seconds = 5.seconds, isRunning = false, isCompleted = false),
+                        type = SegmentStepType.STARTING,
+                        segment = Segment.EMPTY.copy(name = "segment name timer", type = TimeType.TIMER)
+                    ),
+                    SegmentStep(
+                        id = 3,
+                        count = Count(seconds = 0.seconds, isRunning = false, isCompleted = false),
+                        type = SegmentStepType.IN_PROGRESS,
+                        segment = Segment.EMPTY.copy(name = "segment name timer", type = TimeType.TIMER)
+                    )
                 ),
                 isSoundEnabled = true
             )
@@ -328,7 +445,7 @@ class TimerStateConverterTest {
                 ),
                 isSoundEnabled = true,
                 timerActions = TimerViewState.Counting.Actions(
-                    next = TimerViewState.Counting.Actions.Button(
+                    back = TimerViewState.Counting.Actions.Button(
                         iconResId = R.drawable.ic_timer_back,
                         contentDescriptionResId = R.string.content_description_button_back_routine_segment,
                         size = TempoIconButtonSize.Normal
@@ -337,11 +454,16 @@ class TimerStateConverterTest {
                         iconResId =  R.drawable.ic_timer_stop,
                         contentDescriptionResId =  R.string.content_description_button_stop_routine_segment,
                         size = TempoIconButtonSize.Large
+                    ),
+                    next = TimerViewState.Counting.Actions.Button(
+                        iconResId = R.drawable.ic_timer_next,
+                        contentDescriptionResId = R.string.content_description_button_next_routine_segment,
+                        size = TempoIconButtonSize.Normal
                     )
                 )
             )
 
-            val actual = sut.convert(state)
+            val actual = stateConverter.convert(state)
 
             assertEquals(expected, actual)
         }

--- a/features/timer/src/test/java/com/enricog/features/timer/TimerViewModelTest.kt
+++ b/features/timer/src/test/java/com/enricog/features/timer/TimerViewModelTest.kt
@@ -77,7 +77,7 @@ class TimerViewModelTest {
             ),
             isSoundEnabled = true,
             timerActions = TimerViewState.Counting.Actions(
-                next = TimerViewState.Counting.Actions.Button(
+                back = TimerViewState.Counting.Actions.Button(
                     iconResId = R.drawable.ic_timer_back,
                     contentDescriptionResId = R.string.content_description_button_back_routine_segment,
                     size = TempoIconButtonSize.Normal
@@ -85,6 +85,11 @@ class TimerViewModelTest {
                 play = TimerViewState.Counting.Actions.Button(
                     iconResId = R.drawable.ic_timer_play,
                     contentDescriptionResId = R.string.content_description_button_start_routine_segment,
+                    size = TempoIconButtonSize.Normal
+                ),
+                next = TimerViewState.Counting.Actions.Button(
+                    iconResId = R.drawable.ic_timer_next,
+                    contentDescriptionResId = R.string.content_description_button_next_routine_segment,
                     size = TempoIconButtonSize.Normal
                 )
             )
@@ -99,7 +104,7 @@ class TimerViewModelTest {
             ),
             isSoundEnabled = true,
             timerActions = TimerViewState.Counting.Actions(
-                next = TimerViewState.Counting.Actions.Button(
+                back = TimerViewState.Counting.Actions.Button(
                     iconResId = R.drawable.ic_timer_back,
                     contentDescriptionResId = R.string.content_description_button_back_routine_segment,
                     size = TempoIconButtonSize.Normal
@@ -108,12 +113,17 @@ class TimerViewModelTest {
                     iconResId =  R.drawable.ic_timer_stop,
                     contentDescriptionResId =  R.string.content_description_button_stop_routine_segment,
                     size = TempoIconButtonSize.Normal
+                ),
+                next = TimerViewState.Counting.Actions.Button(
+                    iconResId = R.drawable.ic_timer_next,
+                    contentDescriptionResId = R.string.content_description_button_next_routine_segment,
+                    size = TempoIconButtonSize.Normal
                 )
             )
         )
-        val sut = buildSut()
+        val viewModel = buildViewModel()
 
-        sut.viewState.test {
+        viewModel.viewState.test {
             advanceTimeBy(50)
             assertEquals(expectedOnSetup, awaitItem())
             advanceTimeBy(1000)
@@ -134,9 +144,9 @@ class TimerViewModelTest {
 
     @Test
     fun `should play sounds when segment count is completing and sound is enabled`() = coroutineRule {
-        val sut = buildSut()
+        val viewModel = buildViewModel()
 
-        sut.viewState.test {
+        viewModel.viewState.test {
             advanceTimeBy(1000)
 
             advanceTimeBy(3000)
@@ -162,12 +172,12 @@ class TimerViewModelTest {
 
     @Test
     fun `should not play sounds when segment count is completing and sound is disabled`() = coroutineRule {
-        val sut = buildSut()
+        val viewModel = buildViewModel()
 
-        sut.viewState.test {
+        viewModel.viewState.test {
             advanceTimeBy(1000)
 
-            sut.onPlay()
+            viewModel.onPlay()
 
             advanceTimeBy(3000)
             // When segment starting is completing should not play sounds
@@ -202,7 +212,7 @@ class TimerViewModelTest {
             ),
             isSoundEnabled = true,
             timerActions = TimerViewState.Counting.Actions(
-                next = TimerViewState.Counting.Actions.Button(
+                back = TimerViewState.Counting.Actions.Button(
                     iconResId = R.drawable.ic_timer_back,
                     contentDescriptionResId = R.string.content_description_button_back_routine_segment,
                     size = TempoIconButtonSize.Normal
@@ -211,15 +221,20 @@ class TimerViewModelTest {
                     iconResId = R.drawable.ic_timer_play,
                     contentDescriptionResId = R.string.content_description_button_start_routine_segment,
                     size = TempoIconButtonSize.Normal
+                ),
+                next = TimerViewState.Counting.Actions.Button(
+                    iconResId = R.drawable.ic_timer_next,
+                    contentDescriptionResId = R.string.content_description_button_next_routine_segment,
+                    size = TempoIconButtonSize.Normal
                 )
             )
         )
-        val sut = buildSut()
+        val viewModel = buildViewModel()
 
-        sut.viewState.test {
+        viewModel.viewState.test {
             advanceTimeBy(3000)
 
-            sut.onPlay()
+            viewModel.onPlay()
 
             advanceTimeBy(100)
             assertEquals(expected, expectMostRecentItem())
@@ -231,7 +246,7 @@ class TimerViewModelTest {
     }
 
     @Test
-    fun `should restart timer when restart`() = coroutineRule {
+    fun `should reset step count on back`() = coroutineRule {
         val expected = TimerViewState.Counting(
             timeInSeconds = 3,
             stepTitleId = R.string.title_segment_step_type_starting,
@@ -242,7 +257,7 @@ class TimerViewModelTest {
             ),
             isSoundEnabled = true,
             timerActions = TimerViewState.Counting.Actions(
-                next = TimerViewState.Counting.Actions.Button(
+                back = TimerViewState.Counting.Actions.Button(
                     iconResId = R.drawable.ic_timer_back,
                     contentDescriptionResId = R.string.content_description_button_back_routine_segment,
                     size = TempoIconButtonSize.Normal
@@ -251,15 +266,63 @@ class TimerViewModelTest {
                     iconResId = R.drawable.ic_timer_play,
                     contentDescriptionResId = R.string.content_description_button_start_routine_segment,
                     size = TempoIconButtonSize.Normal
+                ),
+                next = TimerViewState.Counting.Actions.Button(
+                    iconResId = R.drawable.ic_timer_next,
+                    contentDescriptionResId = R.string.content_description_button_next_routine_segment,
+                    size = TempoIconButtonSize.Normal
                 )
             )
         )
-        val sut = buildSut()
+        val viewModel = buildViewModel()
 
-        sut.viewState.test {
+        viewModel.viewState.test {
             advanceTimeBy(3000)
 
-            sut.onReset()
+            viewModel.onBack()
+
+            advanceTimeBy(100)
+            assertEquals(expected, expectMostRecentItem())
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `should run next step on next`() = coroutineRule {
+        val expected = TimerViewState.Counting(
+            timeInSeconds = 10,
+            stepTitleId = R.string.title_segment_step_type_in_progress,
+            segmentName = "First Segment",
+            clockBackgroundColor = BackgroundColor(
+                background = TimeTypeColors.TIMER,
+                ripple = null
+            ),
+            isSoundEnabled = true,
+            timerActions = TimerViewState.Counting.Actions(
+                back = TimerViewState.Counting.Actions.Button(
+                    iconResId = R.drawable.ic_timer_back,
+                    contentDescriptionResId = R.string.content_description_button_back_routine_segment,
+                    size = TempoIconButtonSize.Normal
+                ),
+                play = TimerViewState.Counting.Actions.Button(
+                    iconResId = R.drawable.ic_timer_play,
+                    contentDescriptionResId = R.string.content_description_button_start_routine_segment,
+                    size = TempoIconButtonSize.Normal
+                ),
+                next = TimerViewState.Counting.Actions.Button(
+                    iconResId = R.drawable.ic_timer_next,
+                    contentDescriptionResId = R.string.content_description_button_next_routine_segment,
+                    size = TempoIconButtonSize.Normal
+                )
+            )
+        )
+        val viewModel = buildViewModel()
+
+        viewModel.viewState.test {
+            advanceTimeBy(3000)
+
+            viewModel.onNext()
 
             advanceTimeBy(100)
             assertEquals(expected, expectMostRecentItem())
@@ -280,7 +343,7 @@ class TimerViewModelTest {
             ),
             isSoundEnabled = true,
             timerActions = TimerViewState.Counting.Actions(
-                next = TimerViewState.Counting.Actions.Button(
+                back = TimerViewState.Counting.Actions.Button(
                     iconResId = R.drawable.ic_timer_back,
                     contentDescriptionResId = R.string.content_description_button_back_routine_segment,
                     size = TempoIconButtonSize.Normal
@@ -288,6 +351,11 @@ class TimerViewModelTest {
                 play = TimerViewState.Counting.Actions.Button(
                     iconResId = R.drawable.ic_timer_play,
                     contentDescriptionResId = R.string.content_description_button_start_routine_segment,
+                    size = TempoIconButtonSize.Normal
+                ),
+                next = TimerViewState.Counting.Actions.Button(
+                    iconResId = R.drawable.ic_timer_next,
+                    contentDescriptionResId = R.string.content_description_button_next_routine_segment,
                     size = TempoIconButtonSize.Normal
                 )
             )
@@ -302,7 +370,7 @@ class TimerViewModelTest {
             ),
             isSoundEnabled = true,
             timerActions = TimerViewState.Counting.Actions(
-                next = TimerViewState.Counting.Actions.Button(
+                back = TimerViewState.Counting.Actions.Button(
                     iconResId = R.drawable.ic_timer_back,
                     contentDescriptionResId = R.string.content_description_button_back_routine_segment,
                     size = TempoIconButtonSize.Normal
@@ -311,18 +379,23 @@ class TimerViewModelTest {
                     iconResId =  R.drawable.ic_timer_stop,
                     contentDescriptionResId =  R.string.content_description_button_stop_routine_segment,
                     size = TempoIconButtonSize.Normal
+                ),
+                next = TimerViewState.Counting.Actions.Button(
+                    iconResId = R.drawable.ic_timer_next,
+                    contentDescriptionResId = R.string.content_description_button_next_routine_segment,
+                    size = TempoIconButtonSize.Normal
                 )
             )
         )
-        val sut = buildSut()
+        val viewModel = buildViewModel()
 
-        sut.viewState.test {
+        viewModel.viewState.test {
             advanceTimeBy(5000)
 
             advanceTimeBy(1000)
             assertEquals(expectedStartFirstSegment, expectMostRecentItem())
 
-            sut.onReset()
+            viewModel.onReset()
 
             advanceTimeBy(100)
             assertEquals(expectedStart, awaitItem())
@@ -333,23 +406,23 @@ class TimerViewModelTest {
 
     @Test
     fun `should go to routines on done`() = coroutineRule {
-        val sut = buildSut()
+        val viewModel = buildViewModel()
 
-        sut.onDone()
+        viewModel.onDone()
 
         navigator.assertGoTo(route = RoutinesRoute, input = RoutinesRouteInput)
     }
 
     @Test
     fun `should go to routines on close`() = coroutineRule {
-        val sut = buildSut()
+        val viewModel = buildViewModel()
 
-        sut.onClose()
+        viewModel.onClose()
 
         navigator.assertGoTo(route = RoutinesRoute, input = RoutinesRouteInput)
     }
 
-    private fun buildSut(): TimerViewModel {
+    private fun buildViewModel(): TimerViewModel {
         return TimerViewModel(
             savedStateHandle = savedStateHandle,
             dispatchers = coroutineRule.getDispatchers(),

--- a/features/timer/src/test/java/com/enricog/features/timer/TimerViewModelTest.kt
+++ b/features/timer/src/test/java/com/enricog/features/timer/TimerViewModelTest.kt
@@ -77,12 +77,12 @@ class TimerViewModelTest {
             ),
             isSoundEnabled = true,
             timerActions = TimerViewState.Counting.Actions(
-                restart = TimerViewState.Counting.Actions.Button(
+                next = TimerViewState.Counting.Actions.Button(
                     iconResId = R.drawable.ic_timer_back,
-                    contentDescriptionResId = R.string.content_description_button_restart_routine_segment,
+                    contentDescriptionResId = R.string.content_description_button_back_routine_segment,
                     size = TempoIconButtonSize.Normal
                 ),
-                toggleStart = TimerViewState.Counting.Actions.Button(
+                play = TimerViewState.Counting.Actions.Button(
                     iconResId = R.drawable.ic_timer_play,
                     contentDescriptionResId = R.string.content_description_button_start_routine_segment,
                     size = TempoIconButtonSize.Normal
@@ -99,12 +99,12 @@ class TimerViewModelTest {
             ),
             isSoundEnabled = true,
             timerActions = TimerViewState.Counting.Actions(
-                restart = TimerViewState.Counting.Actions.Button(
+                next = TimerViewState.Counting.Actions.Button(
                     iconResId = R.drawable.ic_timer_back,
-                    contentDescriptionResId = R.string.content_description_button_restart_routine_segment,
+                    contentDescriptionResId = R.string.content_description_button_back_routine_segment,
                     size = TempoIconButtonSize.Normal
                 ),
-                toggleStart = TimerViewState.Counting.Actions.Button(
+                play = TimerViewState.Counting.Actions.Button(
                     iconResId =  R.drawable.ic_timer_stop,
                     contentDescriptionResId =  R.string.content_description_button_stop_routine_segment,
                     size = TempoIconButtonSize.Normal
@@ -167,7 +167,7 @@ class TimerViewModelTest {
         sut.viewState.test {
             advanceTimeBy(1000)
 
-            sut.onToggleTimer()
+            sut.onPlay()
 
             advanceTimeBy(3000)
             // When segment starting is completing should not play sounds
@@ -202,12 +202,12 @@ class TimerViewModelTest {
             ),
             isSoundEnabled = true,
             timerActions = TimerViewState.Counting.Actions(
-                restart = TimerViewState.Counting.Actions.Button(
+                next = TimerViewState.Counting.Actions.Button(
                     iconResId = R.drawable.ic_timer_back,
-                    contentDescriptionResId = R.string.content_description_button_restart_routine_segment,
+                    contentDescriptionResId = R.string.content_description_button_back_routine_segment,
                     size = TempoIconButtonSize.Normal
                 ),
-                toggleStart = TimerViewState.Counting.Actions.Button(
+                play = TimerViewState.Counting.Actions.Button(
                     iconResId = R.drawable.ic_timer_play,
                     contentDescriptionResId = R.string.content_description_button_start_routine_segment,
                     size = TempoIconButtonSize.Normal
@@ -219,7 +219,7 @@ class TimerViewModelTest {
         sut.viewState.test {
             advanceTimeBy(3000)
 
-            sut.onToggleTimer()
+            sut.onPlay()
 
             advanceTimeBy(100)
             assertEquals(expected, expectMostRecentItem())
@@ -242,12 +242,12 @@ class TimerViewModelTest {
             ),
             isSoundEnabled = true,
             timerActions = TimerViewState.Counting.Actions(
-                restart = TimerViewState.Counting.Actions.Button(
+                next = TimerViewState.Counting.Actions.Button(
                     iconResId = R.drawable.ic_timer_back,
-                    contentDescriptionResId = R.string.content_description_button_restart_routine_segment,
+                    contentDescriptionResId = R.string.content_description_button_back_routine_segment,
                     size = TempoIconButtonSize.Normal
                 ),
-                toggleStart = TimerViewState.Counting.Actions.Button(
+                play = TimerViewState.Counting.Actions.Button(
                     iconResId = R.drawable.ic_timer_play,
                     contentDescriptionResId = R.string.content_description_button_start_routine_segment,
                     size = TempoIconButtonSize.Normal
@@ -280,12 +280,12 @@ class TimerViewModelTest {
             ),
             isSoundEnabled = true,
             timerActions = TimerViewState.Counting.Actions(
-                restart = TimerViewState.Counting.Actions.Button(
+                next = TimerViewState.Counting.Actions.Button(
                     iconResId = R.drawable.ic_timer_back,
-                    contentDescriptionResId = R.string.content_description_button_restart_routine_segment,
+                    contentDescriptionResId = R.string.content_description_button_back_routine_segment,
                     size = TempoIconButtonSize.Normal
                 ),
-                toggleStart = TimerViewState.Counting.Actions.Button(
+                play = TimerViewState.Counting.Actions.Button(
                     iconResId = R.drawable.ic_timer_play,
                     contentDescriptionResId = R.string.content_description_button_start_routine_segment,
                     size = TempoIconButtonSize.Normal
@@ -302,12 +302,12 @@ class TimerViewModelTest {
             ),
             isSoundEnabled = true,
             timerActions = TimerViewState.Counting.Actions(
-                restart = TimerViewState.Counting.Actions.Button(
+                next = TimerViewState.Counting.Actions.Button(
                     iconResId = R.drawable.ic_timer_back,
-                    contentDescriptionResId = R.string.content_description_button_restart_routine_segment,
+                    contentDescriptionResId = R.string.content_description_button_back_routine_segment,
                     size = TempoIconButtonSize.Normal
                 ),
-                toggleStart = TimerViewState.Counting.Actions.Button(
+                play = TimerViewState.Counting.Actions.Button(
                     iconResId =  R.drawable.ic_timer_stop,
                     contentDescriptionResId =  R.string.content_description_button_stop_routine_segment,
                     size = TempoIconButtonSize.Normal


### PR DESCRIPTION
Add a feature to navigate between the steps that compose a routine in the timer. In this way, the user can easily skip or go back to a previous step of a routine.

### Remarkable changes
The `TimerState` has been reviewed: instead of calculating every time what is supposed to be the next or previous step, on setup, the full list of steps that compose a routine is exploded. This allows to simplify the navigation between steps that basically now is driven by a simple index pointing to the step that is running.