### PR TITLE
Refactor: rename routine preparation time

### DIFF
--- a/data/local/database/schemas/com.enricog.data.local.database.TempoDatabase/3.json
+++ b/data/local/database/schemas/com.enricog.data.local.database.TempoDatabase/3.json
@@ -1,0 +1,136 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 3,
+    "identityHash": "da8b643f814ea4b7f59bcec978b7e078",
+    "entities": [
+      {
+        "tableName": "Routines",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`routineId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `preparationTimeInSeconds` INTEGER NOT NULL, `createdAt` TEXT NOT NULL, `updatedAt` TEXT NOT NULL, `rank` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "routineId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "preparationTime",
+            "columnName": "preparationTimeInSeconds",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rank",
+            "columnName": "rank",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "routineId"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "Segments",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`segmentId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `routineId_fk` INTEGER NOT NULL, `name` TEXT NOT NULL, `timeInSeconds` INTEGER NOT NULL, `type` TEXT NOT NULL, `rank` TEXT NOT NULL, FOREIGN KEY(`routineId_fk`) REFERENCES `Routines`(`routineId`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "segmentId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "routineId",
+            "columnName": "routineId_fk",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timeInSeconds",
+            "columnName": "timeInSeconds",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rank",
+            "columnName": "rank",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "segmentId"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_Segments_routineId_fk",
+            "unique": false,
+            "columnNames": [
+              "routineId_fk"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_Segments_routineId_fk` ON `${TABLE_NAME}` (`routineId_fk`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "Routines",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "routineId_fk"
+            ],
+            "referencedColumns": [
+              "routineId"
+            ]
+          }
+        ]
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'da8b643f814ea4b7f59bcec978b7e078')"
+    ]
+  }
+}

--- a/data/local/database/src/androidTest/java/com/enricog/data/local/database/migrations/MigrationFrom2To3Test.kt
+++ b/data/local/database/src/androidTest/java/com/enricog/data/local/database/migrations/MigrationFrom2To3Test.kt
@@ -1,0 +1,38 @@
+package com.enricog.data.local.database.migrations
+
+import androidx.room.testing.MigrationTestHelper
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.enricog.data.local.database.TempoDatabase
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class MigrationFrom2To3Test {
+
+    @get:Rule
+    val helper: MigrationTestHelper = MigrationTestHelper(
+        InstrumentationRegistry.getInstrumentation(),
+        TempoDatabase::class.java
+    )
+
+    @Test
+    fun shouldApplyDatabaseMigration() {
+        helper.createDatabase(TEST_DB, 2).apply {
+            execSQL(
+                """
+                INSERT INTO Routines (name, startTimeOffsetInSeconds, createdAt, updatedAt, rank)
+                VALUES ('Routine 1', 0, '2022-12-25T17:49:30+01:00', '2022-12-25T17:49:30+01:00', 'bbbbbb')
+            """.trimIndent()
+            )
+            close()
+        }
+
+        helper.runMigrationsAndValidate(TEST_DB, 3, true, MigrationFrom2To3)
+    }
+
+    private companion object {
+        private const val TEST_DB = "migration-test"
+    }
+}

--- a/data/local/database/src/androidTest/java/com/enricog/data/local/database/routines/RoutineDataSourceImplTest.kt
+++ b/data/local/database/src/androidTest/java/com/enricog/data/local/database/routines/RoutineDataSourceImplTest.kt
@@ -63,7 +63,7 @@ class RoutineDataSourceImplTest {
         val internalRoutine = InternalRoutine(
             id = 1,
             name = "name",
-            startTimeOffsetInSeconds = 10,
+            preparationTime = 10,
             createdAt = now,
             updatedAt = now,
             rank = "abcdef"
@@ -71,7 +71,7 @@ class RoutineDataSourceImplTest {
         val routine = Routine(
             id = 1.asID,
             name = "name",
-            startTimeOffset = 10.seconds,
+            preparationTime = 10.seconds,
             createdAt = now,
             updatedAt = now,
             segments = listOf(
@@ -109,7 +109,7 @@ class RoutineDataSourceImplTest {
         val internalRoutine = InternalRoutine(
             id = 1,
             name = "name",
-            startTimeOffsetInSeconds = 10,
+            preparationTime = 10,
             createdAt = now,
             updatedAt = now,
             rank = "abcdef"
@@ -117,7 +117,7 @@ class RoutineDataSourceImplTest {
         val expected = Routine(
             id = 1.asID,
             name = "name",
-            startTimeOffset = 10.seconds,
+            preparationTime = 10.seconds,
             createdAt = now,
             updatedAt = now,
             segments = listOf(
@@ -154,7 +154,7 @@ class RoutineDataSourceImplTest {
         val internalRoutine = InternalRoutine(
             id = 1,
             name = "name",
-            startTimeOffsetInSeconds = 10,
+            preparationTime = 10,
             createdAt = now,
             updatedAt = now,
             rank = "abcdef"
@@ -162,7 +162,7 @@ class RoutineDataSourceImplTest {
         val routine = Routine(
             id = 1.asID,
             name = "name",
-            startTimeOffset = 10.seconds,
+            preparationTime = 10.seconds,
             createdAt = now,
             updatedAt = now,
             segments = listOf(
@@ -200,7 +200,7 @@ class RoutineDataSourceImplTest {
         val internalRoutine = InternalRoutine(
             id = 1,
             name = "name",
-            startTimeOffsetInSeconds = 10,
+            preparationTime = 10,
             createdAt = now,
             updatedAt = now,
             rank = "abcdef"
@@ -208,7 +208,7 @@ class RoutineDataSourceImplTest {
         val expected = Routine(
             id = 1.asID,
             name = "name",
-            startTimeOffset = 10.seconds,
+            preparationTime = 10.seconds,
             createdAt = now,
             updatedAt = now,
             segments = listOf(
@@ -238,7 +238,7 @@ class RoutineDataSourceImplTest {
         val routine = Routine(
             id = 0.asID,
             name = "name",
-            startTimeOffset = 10.seconds,
+            preparationTime = 10.seconds,
             createdAt = max,
             updatedAt = max,
             segments = listOf(
@@ -255,7 +255,7 @@ class RoutineDataSourceImplTest {
         val expected = Routine(
             id = 1.asID,
             name = "name",
-            startTimeOffset = 10.seconds,
+            preparationTime = 10.seconds,
             createdAt = now,
             updatedAt = now,
             segments = listOf(
@@ -293,7 +293,7 @@ class RoutineDataSourceImplTest {
         val internalRoutine = InternalRoutine(
             id = 1,
             name = "name",
-            startTimeOffsetInSeconds = 10,
+            preparationTime = 10,
             createdAt = max,
             updatedAt = max,
             rank = "abcdef"
@@ -301,7 +301,7 @@ class RoutineDataSourceImplTest {
         val routine = Routine(
             id = 1.asID,
             name = "name2",
-            startTimeOffset = 10.seconds,
+            preparationTime = 10.seconds,
             createdAt = max,
             updatedAt = now,
             segments = listOf(
@@ -342,7 +342,7 @@ class RoutineDataSourceImplTest {
         val internalRoutine = InternalRoutine(
             id = 1,
             name = "name",
-            startTimeOffsetInSeconds = 10,
+            preparationTime = 10,
             createdAt = max,
             updatedAt = max,
             rank = "abcdef"
@@ -350,7 +350,7 @@ class RoutineDataSourceImplTest {
         val routine = Routine(
             id = 1.asID,
             name = "name2",
-            startTimeOffset = 10.seconds,
+            preparationTime = 10.seconds,
             createdAt = max,
             updatedAt = now,
             segments = listOf(
@@ -391,7 +391,7 @@ class RoutineDataSourceImplTest {
         val internalRoutine = InternalRoutine(
             id = 1,
             name = "name",
-            startTimeOffsetInSeconds = 10,
+            preparationTime = 10,
             createdAt = max,
             updatedAt = max,
             rank = "abcdef"
@@ -399,7 +399,7 @@ class RoutineDataSourceImplTest {
         val routine = Routine(
             id = 1.asID,
             name = "name2",
-            startTimeOffset = 10.seconds,
+            preparationTime = 10.seconds,
             createdAt = max,
             updatedAt = now,
             segments = emptyList(),
@@ -424,7 +424,7 @@ class RoutineDataSourceImplTest {
         val internalRoutine = InternalRoutine(
             id = 1,
             name = "name",
-            startTimeOffsetInSeconds = 10,
+            preparationTime = 10,
             createdAt = max,
             updatedAt = max,
             rank = "abcdef"
@@ -432,7 +432,7 @@ class RoutineDataSourceImplTest {
         val routine = Routine(
             id = 1.asID,
             name = "name2",
-            startTimeOffset = 10.seconds,
+            preparationTime = 10.seconds,
             createdAt = max,
             updatedAt = max,
             segments = listOf(
@@ -449,7 +449,7 @@ class RoutineDataSourceImplTest {
         val expected = Routine(
             id = 1.asID,
             name = "name2",
-            startTimeOffset = 10.seconds,
+            preparationTime = 10.seconds,
             createdAt = max,
             updatedAt = now,
             segments = listOf(
@@ -489,7 +489,7 @@ class RoutineDataSourceImplTest {
         val internalRoutine = InternalRoutine(
             id = 1,
             name = "name",
-            startTimeOffsetInSeconds = 10,
+            preparationTime = 10,
             createdAt = max,
             updatedAt = max,
             rank = "abcdef"
@@ -497,7 +497,7 @@ class RoutineDataSourceImplTest {
         val routine = Routine(
             id = 1.asID,
             name = "name2",
-            startTimeOffset = 10.seconds,
+            preparationTime = 10.seconds,
             createdAt = max,
             updatedAt = max,
             segments = listOf(
@@ -514,7 +514,7 @@ class RoutineDataSourceImplTest {
         val expected = Routine(
             id = 1.asID,
             name = "name2",
-            startTimeOffset = 10.seconds,
+            preparationTime = 10.seconds,
             createdAt = max,
             updatedAt = now,
             segments = listOf(
@@ -563,7 +563,7 @@ class RoutineDataSourceImplTest {
         val internalRoutine = InternalRoutine(
             id = 1,
             name = "name",
-            startTimeOffsetInSeconds = 10,
+            preparationTime = 10,
             createdAt = max,
             updatedAt = max,
             rank = "abcdef"
@@ -571,7 +571,7 @@ class RoutineDataSourceImplTest {
         val routine = Routine(
             id = 1.asID,
             name = "name2",
-            startTimeOffset = 10.seconds,
+            preparationTime = 10.seconds,
             createdAt = max,
             updatedAt = max,
             segments = listOf(
@@ -595,7 +595,7 @@ class RoutineDataSourceImplTest {
         val expected = Routine(
             id = 1.asID,
             name = "name2",
-            startTimeOffset = 10.seconds,
+            preparationTime = 10.seconds,
             createdAt = max,
             updatedAt = now,
             segments = listOf(
@@ -642,7 +642,7 @@ class RoutineDataSourceImplTest {
         val internalRoutine = InternalRoutine(
             id = 1,
             name = "name",
-            startTimeOffsetInSeconds = 10,
+            preparationTime = 10,
             createdAt = now,
             updatedAt = now,
             rank = "abcdef"
@@ -650,7 +650,7 @@ class RoutineDataSourceImplTest {
         val routine = Routine(
             id = 1.asID,
             name = "name",
-            startTimeOffset = 10.seconds,
+            preparationTime = 10.seconds,
             createdAt = now,
             updatedAt = now,
             segments = listOf(
@@ -679,7 +679,7 @@ class RoutineDataSourceImplTest {
     private fun assertRoutineEquals(expected: Routine, actual: Routine) {
         assertThat(actual.id).isEqualTo(expected.id)
         assertThat(actual.name).isEqualTo(expected.name)
-        assertThat(actual.startTimeOffset).isEqualTo(expected.startTimeOffset)
+        assertThat(actual.preparationTime).isEqualTo(expected.preparationTime)
         assertThat(actual.segments).isEqualTo(expected.segments)
         assertThat(actual.createdAt.truncatedTo(ChronoUnit.HOURS))
             .isEqualTo(expected.createdAt.truncatedTo(ChronoUnit.HOURS))

--- a/data/local/database/src/main/java/com/enricog/data/local/database/TempoDatabase.kt
+++ b/data/local/database/src/main/java/com/enricog/data/local/database/TempoDatabase.kt
@@ -8,6 +8,7 @@ import androidx.room.TypeConverters
 import com.enricog.data.local.database.converter.OffsetDateTimeConverter
 import com.enricog.data.local.database.converter.TimeTypeConverter
 import com.enricog.data.local.database.migrations.MigrationFrom1To2
+import com.enricog.data.local.database.migrations.MigrationFrom2To3
 import com.enricog.data.local.database.routines.dao.RoutineDao
 import com.enricog.data.local.database.routines.dao.SegmentDao
 import com.enricog.data.local.database.routines.model.InternalRoutine
@@ -18,7 +19,7 @@ import com.enricog.data.local.database.routines.model.InternalSegment
         InternalRoutine::class,
         InternalSegment::class,
     ],
-    version = 2
+    version = 3
 )
 @TypeConverters(
     TimeTypeConverter::class,
@@ -43,6 +44,7 @@ internal abstract class TempoDatabase : RoomDatabase() {
             return Room
                 .databaseBuilder(context.applicationContext, TempoDatabase::class.java, "Tempo.db")
                 .addMigrations(MigrationFrom1To2)
+                .addMigrations(MigrationFrom2To3)
                 .build()
         }
     }

--- a/data/local/database/src/main/java/com/enricog/data/local/database/migrations/MigrationFrom2To3.kt
+++ b/data/local/database/src/main/java/com/enricog/data/local/database/migrations/MigrationFrom2To3.kt
@@ -6,6 +6,19 @@ import androidx.sqlite.db.SupportSQLiteDatabase
 internal object MigrationFrom2To3 : Migration(2, 3) {
 
     override fun migrate(database: SupportSQLiteDatabase) {
-        database.execSQL("ALTER TABLE Routines RENAME COLUMN 'startTimeOffsetInSeconds' TO 'preparationTimeInSeconds';")
+        database.beginTransaction()
+        try {
+            database.execSQL("CREATE TABLE RoutinesTemp (routineId INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, name TEXT NOT NULL, preparationTimeInSeconds INTEGER NOT NULL, createdAt TEXT NOT NULL, updatedAt TEXT NOT NULL, rank TEXT NOT NULL)")
+
+            database.execSQL("INSERT INTO RoutinesTemp(routineId, name, preparationTimeInSeconds, createdAt, updatedAt, rank) SELECT routineId, name, startTimeOffsetInSeconds, createdAt, updatedAt, rank FROM Routines")
+
+            database.execSQL("DROP TABLE Routines")
+
+            database.execSQL("ALTER TABLE RoutinesTemp RENAME TO Routines")
+
+            database.setTransactionSuccessful()
+        } finally {
+            database.endTransaction()
+        }
     }
 }

--- a/data/local/database/src/main/java/com/enricog/data/local/database/migrations/MigrationFrom2To3.kt
+++ b/data/local/database/src/main/java/com/enricog/data/local/database/migrations/MigrationFrom2To3.kt
@@ -1,0 +1,11 @@
+package com.enricog.data.local.database.migrations
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+internal object MigrationFrom2To3 : Migration(2, 3) {
+
+    override fun migrate(database: SupportSQLiteDatabase) {
+        database.execSQL("ALTER TABLE Routines RENAME COLUMN startTimeOffsetInSeconds TO preparationTimeInSeconds;")
+    }
+}

--- a/data/local/database/src/main/java/com/enricog/data/local/database/migrations/MigrationFrom2To3.kt
+++ b/data/local/database/src/main/java/com/enricog/data/local/database/migrations/MigrationFrom2To3.kt
@@ -6,6 +6,6 @@ import androidx.sqlite.db.SupportSQLiteDatabase
 internal object MigrationFrom2To3 : Migration(2, 3) {
 
     override fun migrate(database: SupportSQLiteDatabase) {
-        database.execSQL("ALTER TABLE Routines RENAME COLUMN startTimeOffsetInSeconds TO preparationTimeInSeconds;")
+        database.execSQL("ALTER TABLE Routines RENAME COLUMN 'startTimeOffsetInSeconds' TO 'preparationTimeInSeconds';")
     }
 }

--- a/data/local/database/src/main/java/com/enricog/data/local/database/routines/model/InternalRoutine.kt
+++ b/data/local/database/src/main/java/com/enricog/data/local/database/routines/model/InternalRoutine.kt
@@ -14,7 +14,7 @@ import java.time.OffsetDateTime
 internal data class InternalRoutine(
     @PrimaryKey(autoGenerate = true) @ColumnInfo(name = "routineId") val id: Long,
     @ColumnInfo(name = "name") val name: String,
-    @ColumnInfo(name = "startTimeOffsetInSeconds") val startTimeOffsetInSeconds: Long,
+    @ColumnInfo(name = "preparationTimeInSeconds") val preparationTime: Long,
     @ColumnInfo(name = "createdAt") val createdAt: OffsetDateTime,
     @ColumnInfo(name = "updatedAt") val updatedAt: OffsetDateTime,
     @ColumnInfo(name = "rank") val rank: String
@@ -23,7 +23,7 @@ internal data class InternalRoutine(
         return Routine(
             id = ID.from(id),
             name = name,
-            startTimeOffset = startTimeOffsetInSeconds.seconds,
+            preparationTime = preparationTime.seconds,
             createdAt = createdAt,
             updatedAt = updatedAt,
             segments = segments
@@ -38,7 +38,7 @@ internal fun Routine.toInternal(): InternalRoutine {
     return InternalRoutine(
         id = id.toLong(),
         name = name,
-        startTimeOffsetInSeconds = startTimeOffset.value,
+        preparationTime = preparationTime.value,
         createdAt = createdAt,
         updatedAt = updatedAt,
         rank = rank.toString()

--- a/data/local/database/src/test/java/com/enricog/data/local/database/routines/model/InternalRoutineTest.kt
+++ b/data/local/database/src/test/java/com/enricog/data/local/database/routines/model/InternalRoutineTest.kt
@@ -19,7 +19,7 @@ class InternalRoutineTest {
         val routine = Routine(
             id = 1.asID,
             name = "name",
-            startTimeOffset = 2.seconds,
+            preparationTime = 2.seconds,
             createdAt = now,
             updatedAt = now,
             segments = listOf(
@@ -36,7 +36,7 @@ class InternalRoutineTest {
         val expected = InternalRoutine(
             id = 1,
             name = "name",
-            startTimeOffsetInSeconds = 2,
+            preparationTime = 2,
             createdAt = now,
             updatedAt = now,
             rank = "abcdef"
@@ -63,7 +63,7 @@ class InternalRoutineTest {
         val internalRoutine = InternalRoutine(
             id = 1,
             name = "name",
-            startTimeOffsetInSeconds = 2,
+            preparationTime = 2,
             createdAt = now,
             updatedAt = now,
             rank = "abcdef"
@@ -71,7 +71,7 @@ class InternalRoutineTest {
         val expected = Routine(
             id = 1.asID,
             name = "name",
-            startTimeOffset = 2.seconds,
+            preparationTime = 2.seconds,
             createdAt = now,
             updatedAt = now,
             segments = listOf(

--- a/data/local/database/src/test/java/com/enricog/data/local/database/routines/model/InternalRoutineWithSegmentsTest.kt
+++ b/data/local/database/src/test/java/com/enricog/data/local/database/routines/model/InternalRoutineWithSegmentsTest.kt
@@ -28,7 +28,7 @@ class InternalRoutineWithSegmentsTest {
         val internalRoutine = InternalRoutine(
             id = 1,
             name = "name",
-            startTimeOffsetInSeconds = 2,
+            preparationTime = 2,
             createdAt = now,
             updatedAt = now,
             rank = "abcdef"
@@ -36,7 +36,7 @@ class InternalRoutineWithSegmentsTest {
         val expected = Routine(
             id = 1.asID,
             name = "name",
-            startTimeOffset = 2.seconds,
+            preparationTime = 2.seconds,
             createdAt = now,
             updatedAt = now,
             segments = listOf(

--- a/data/routines/api/src/main/java/com/enricog/data/routines/api/entities/Routine.kt
+++ b/data/routines/api/src/main/java/com/enricog/data/routines/api/entities/Routine.kt
@@ -9,7 +9,7 @@ import java.time.OffsetDateTime
 data class Routine(
     val id: ID,
     val name: String,
-    val startTimeOffset: Seconds,
+    val preparationTime: Seconds,
     val createdAt: OffsetDateTime,
     val updatedAt: OffsetDateTime,
     val segments: List<Segment>,
@@ -17,11 +17,11 @@ data class Routine(
 ) {
 
     init {
-        require(value = startTimeOffset <= MAX_START_TIME_OFFSET) {
-            "startTimeOffset value exceed the maximum value"
+        require(value = preparationTime <= MAX_PREPARATION_TIME) {
+            "preparationTime value exceed the maximum value"
         }
-        require(value = startTimeOffset >= 0.seconds) {
-            "startTimeOffset must be positive"
+        require(value = preparationTime >= 0.seconds) {
+            "preparationTime must be positive"
         }
     }
 
@@ -32,7 +32,7 @@ data class Routine(
         get() {
             val segmentsTotalTime = segments.map { it.time }
                 .reduce { acc, time -> acc + time }
-            val preparationTotalTime = startTimeOffset * segments.count {
+            val preparationTotalTime = preparationTime * segments.count {
                 it.type.requirePreparationTime
             }
             if (segmentsTotalTime == 0.seconds)
@@ -53,7 +53,7 @@ data class Routine(
             return Routine(
                 id = ID.new(),
                 name = "",
-                startTimeOffset = 0.seconds,
+                preparationTime = 0.seconds,
                 createdAt = now,
                 updatedAt = now,
                 segments = emptyList(),
@@ -61,7 +61,7 @@ data class Routine(
             )
         }
 
-        val MAX_START_TIME_OFFSET = 60.seconds
+        val MAX_PREPARATION_TIME = 60.seconds
     }
 }
 

--- a/data/routines/api/src/test/java/com/enricog/data/routines/api/entities/RoutineTest.kt
+++ b/data/routines/api/src/test/java/com/enricog/data/routines/api/entities/RoutineTest.kt
@@ -1,6 +1,6 @@
 package com.enricog.data.routines.api.entities
 
-import com.enricog.data.routines.api.entities.Routine.Companion.MAX_START_TIME_OFFSET
+import com.enricog.data.routines.api.entities.Routine.Companion.MAX_PREPARATION_TIME
 import com.enricog.entities.ID
 import com.enricog.entities.Rank
 import com.enricog.entities.asID
@@ -13,14 +13,14 @@ import java.time.OffsetDateTime
 class RoutineTest {
 
     @Test
-    fun `on instantiation should throw exception when start offset time is more than max`() {
-        val startTimeOffset = MAX_START_TIME_OFFSET + 1.seconds
+    fun `on instantiation should throw exception when preparation time is more than max`() {
+        val preparationTime = MAX_PREPARATION_TIME + 1.seconds
 
         assertThrows(IllegalArgumentException::class.java) {
             Routine(
                 id = 0.asID,
                 name = "",
-                startTimeOffset = startTimeOffset,
+                preparationTime = preparationTime,
                 createdAt = OffsetDateTime.MAX,
                 updatedAt = OffsetDateTime.MAX,
                 segments = emptyList(),
@@ -30,14 +30,14 @@ class RoutineTest {
     }
 
     @Test
-    fun `on init should throw exception when start offset time is less than zero`() {
-        val startTimeOffset = (-1).seconds
+    fun `on init should throw exception when preparation time is less than zero`() {
+        val preparationTime = (-1).seconds
 
         assertThrows(IllegalArgumentException::class.java) {
             Routine(
                 id = 0.asID,
                 name = "",
-                startTimeOffset = startTimeOffset,
+                preparationTime = preparationTime,
                 createdAt = OffsetDateTime.MAX,
                 updatedAt = OffsetDateTime.MAX,
                 segments = emptyList(),
@@ -48,13 +48,13 @@ class RoutineTest {
 
     @Test
     @Suppress("UnusedDataClassCopyResult")
-    fun `on copy should throw exception when start offset time is more than max`() {
-        val startTimeOffset = MAX_START_TIME_OFFSET + 1.seconds
+    fun `on copy should throw exception when preparation time is more than max`() {
+        val preparationTime = MAX_PREPARATION_TIME + 1.seconds
 
         val routine = Routine(
             id = 0.asID,
             name = "",
-            startTimeOffset = 50.seconds,
+            preparationTime = 50.seconds,
             createdAt = OffsetDateTime.MAX,
             updatedAt = OffsetDateTime.MAX,
             segments = emptyList(),
@@ -62,26 +62,26 @@ class RoutineTest {
         )
 
         assertThrows(IllegalArgumentException::class.java) {
-            routine.copy(startTimeOffset = startTimeOffset)
+            routine.copy(preparationTime = preparationTime)
         }
     }
 
     @Test
     @Suppress("UnusedDataClassCopyResult")
-    fun `on copy should throw exception when start offset time is less that zero`() {
-        val startTimeOffset = (-1).seconds
+    fun `on copy should throw exception when preparation time is less that zero`() {
+        val preparationTime = (-1).seconds
 
         val routine = Routine(
             id = 0.asID,
             name = "",
-            startTimeOffset = 50.seconds,
+            preparationTime = 50.seconds,
             createdAt = OffsetDateTime.MAX,
             updatedAt = OffsetDateTime.MAX,
             segments = emptyList(),
             rank = Rank.from("aaaaaa")
         )
         assertThrows(IllegalArgumentException::class.java) {
-            routine.copy(startTimeOffset = startTimeOffset)
+            routine.copy(preparationTime = preparationTime)
         }
     }
 
@@ -90,7 +90,7 @@ class RoutineTest {
         Routine(
             id = 0.asID,
             name = "",
-            startTimeOffset = MAX_START_TIME_OFFSET,
+            preparationTime = MAX_PREPARATION_TIME,
             createdAt = OffsetDateTime.MAX,
             updatedAt = OffsetDateTime.MAX,
             segments = emptyList(),
@@ -104,13 +104,13 @@ class RoutineTest {
         val routine = Routine(
             id = 0.asID,
             name = "",
-            startTimeOffset = 50.seconds,
+            preparationTime = 50.seconds,
             createdAt = OffsetDateTime.MAX,
             updatedAt = OffsetDateTime.MAX,
             segments = emptyList(),
             rank = Rank.from("aaaaaa")
         )
-        routine.copy(startTimeOffset = MAX_START_TIME_OFFSET)
+        routine.copy(preparationTime = MAX_PREPARATION_TIME)
     }
 
     @Test
@@ -118,7 +118,7 @@ class RoutineTest {
         val routine = Routine(
             id = 0.asID,
             name = "",
-            startTimeOffset = 30.seconds,
+            preparationTime = 30.seconds,
             createdAt = OffsetDateTime.MAX,
             updatedAt = OffsetDateTime.MAX,
             segments = listOf(
@@ -144,7 +144,7 @@ class RoutineTest {
         val routine = Routine(
             id = 0.asID,
             name = "",
-            startTimeOffset = 30.seconds,
+            preparationTime = 30.seconds,
             createdAt = OffsetDateTime.MAX,
             updatedAt = OffsetDateTime.MAX,
             segments = listOf(

--- a/data/routines/testing/src/main/java/com/enricog/data/routines/testing/entities/RoutineExtensions.kt
+++ b/data/routines/testing/src/main/java/com/enricog/data/routines/testing/entities/RoutineExtensions.kt
@@ -12,7 +12,7 @@ val Routine.Companion.EMPTY: Routine
     get() = Routine(
         id = 0.asID,
         name = "",
-        startTimeOffset = 0.seconds,
+        preparationTime = 0.seconds,
         createdAt = OffsetDateTime.of(2020, 12, 20, 10, 10, 0, 0, ZoneOffset.UTC),
         updatedAt = OffsetDateTime.of(2020, 12, 20, 10, 10, 0, 0, ZoneOffset.UTC),
         segments = emptyList(),

--- a/features/routines/src/androidTest/java/com/enricog/features/routines/detail/preparation_time/PreparationTimeInfoSceneKtTest.kt
+++ b/features/routines/src/androidTest/java/com/enricog/features/routines/detail/preparation_time/PreparationTimeInfoSceneKtTest.kt
@@ -1,4 +1,4 @@
-package com.enricog.features.routines.detail.start_time
+package com.enricog.features.routines.detail.preparation_time
 
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
@@ -8,7 +8,7 @@ import com.enricog.ui.theme.TempoTheme
 import org.junit.Rule
 import org.junit.Test
 
-class StartTimeInfoSceneKtTest {
+class PreparationTimeInfoSceneKtTest {
 
     @get:Rule
     val composeRule = createComposeRule()
@@ -17,11 +17,11 @@ class StartTimeInfoSceneKtTest {
     fun validateElements() = composeRule {
         setContent {
             TempoTheme {
-                StartTimeInfoScene()
+                PreparationTimeInfoScene()
             }
         }
 
-        onNodeWithTag(StartTimeInfoTitleTestTag).assertIsDisplayed()
-        onNodeWithTag(StartTimeInfoDescriptionTestTag).assertIsDisplayed()
+        onNodeWithTag(PreparationTimeInfoTitleTestTag).assertIsDisplayed()
+        onNodeWithTag(PreparationTimeInfoDescriptionTestTag).assertIsDisplayed()
     }
 }

--- a/features/routines/src/androidTest/java/com/enricog/features/routines/detail/routine/RoutineScreenKtTest.kt
+++ b/features/routines/src/androidTest/java/com/enricog/features/routines/detail/routine/RoutineScreenKtTest.kt
@@ -25,7 +25,7 @@ class RoutineScreenKtTest {
         val viewState = RoutineViewState.Idle
         val inputs = RoutineInputs(
             name = "".toTextFieldValue(),
-            startTimeOffset = "".timeText
+            preparationTime = "".timeText
         )
 
         setContent {
@@ -33,9 +33,9 @@ class RoutineScreenKtTest {
                 viewState.Compose(
                     inputs = inputs,
                     onRoutineNameChange = {},
-                    onStartTimeOffsetChange = {},
+                    onPreparationTimeChange = {},
                     onRoutineSave = {},
-                    onStartTimeInfo = {},
+                    onPreparationTimeInfo = {},
                     onRetryLoad = {},
                     onSnackbarEvent = {}
                 )
@@ -54,7 +54,7 @@ class RoutineScreenKtTest {
         )
         val inputs = RoutineInputs(
             name = "".toTextFieldValue(),
-            startTimeOffset = "".timeText
+            preparationTime = "".timeText
         )
 
         setContent {
@@ -62,9 +62,9 @@ class RoutineScreenKtTest {
                 viewState.Compose(
                     inputs = inputs,
                     onRoutineNameChange = {},
-                    onStartTimeOffsetChange = {},
+                    onPreparationTimeChange = {},
                     onRoutineSave = {},
-                    onStartTimeInfo = {},
+                    onPreparationTimeInfo = {},
                     onRetryLoad = {},
                     onSnackbarEvent = {}
                 )
@@ -80,16 +80,16 @@ class RoutineScreenKtTest {
         val viewState = RoutineViewState.Error(throwable = Exception())
         val inputs = RoutineInputs(
             name = "".toTextFieldValue(),
-            startTimeOffset = "".timeText
+            preparationTime = "".timeText
         )
 
         setContent {
             viewState.Compose(
                 inputs = inputs,
                 onRoutineNameChange = {},
-                onStartTimeOffsetChange = {},
+                onPreparationTimeChange = {},
                 onRoutineSave = {},
-                onStartTimeInfo = {},
+                onPreparationTimeInfo = {},
                 onRetryLoad = {},
                 onSnackbarEvent = {}
             )

--- a/features/routines/src/main/java/com/enricog/features/routines/RoutinesNavigationGraph.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/RoutinesNavigationGraph.kt
@@ -4,13 +4,13 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.navigation
 import com.enricog.features.routines.detail.routine.RoutineScreen
 import com.enricog.features.routines.detail.segment.SegmentScreen
-import com.enricog.features.routines.detail.start_time.StartTimeInfoScene
+import com.enricog.features.routines.detail.preparation_time.PreparationTimeInfoScene
 import com.enricog.features.routines.detail.summary.RoutineSummaryScreen
 import com.enricog.features.routines.list.RoutinesScreen
 import com.enricog.navigation.api.extensions.navViewModel
 import com.enricog.navigation.api.routes.RoutinesRoute
 import com.enricog.navigation.api.routes.RoutineRoute.compose as composeRoutine
-import com.enricog.navigation.api.routes.RoutineStartTimeInfoRoute.compose as bottomSheetRoutineStartTimeInfo
+import com.enricog.navigation.api.routes.RoutinePreparationTimeInfoRoute.compose as bottomSheetRoutinePreparationTimeInfo
 import com.enricog.navigation.api.routes.RoutineSummaryRoute.compose as composeRoutineSummary
 import com.enricog.navigation.api.routes.RoutinesRoute.compose as composeRoutines
 import com.enricog.navigation.api.routes.SegmentRoute.compose as composeSegment
@@ -36,8 +36,8 @@ fun NavGraphBuilder.RoutinesNavigation() {
             SegmentScreen(viewModel = navViewModel(it))
         }
 
-        bottomSheetRoutineStartTimeInfo {
-            StartTimeInfoScene()
+        bottomSheetRoutinePreparationTimeInfo {
+            PreparationTimeInfoScene()
         }
     }
 }

--- a/features/routines/src/main/java/com/enricog/features/routines/detail/preparation_time/PreparationTimeInfoScene.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/detail/preparation_time/PreparationTimeInfoScene.kt
@@ -1,4 +1,4 @@
-package com.enricog.features.routines.detail.start_time
+package com.enricog.features.routines.detail.preparation_time
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.WindowInsets
@@ -16,13 +16,13 @@ import com.enricog.features.routines.R
 import com.enricog.ui.components.text.TempoText
 import com.enricog.ui.theme.TempoTheme
 
-internal const val StartTimeInfoSceneTestTag = "StartTimeInfoSceneTestTag"
+internal const val PreparationTimeInfoSceneTestTag = "PreparationTimeInfoSceneTestTag"
 
-internal const val StartTimeInfoTitleTestTag = "StartTimeInfoTitleTestTag"
-internal const val StartTimeInfoDescriptionTestTag = "StartTimeInfoDescriptionTestTag"
+internal const val PreparationTimeInfoTitleTestTag = "PreparationTimeInfoTitleTestTag"
+internal const val PreparationTimeInfoDescriptionTestTag = "PreparationTimeInfoDescriptionTestTag"
 
 @Composable
-internal fun StartTimeInfoScene() {
+internal fun PreparationTimeInfoScene() {
     val scrollState = rememberScrollState()
 
     Column(
@@ -31,16 +31,16 @@ internal fun StartTimeInfoScene() {
             .windowInsetsPadding(WindowInsets.navigationBars)
             .windowInsetsPadding(WindowInsets.statusBars)
             .padding(TempoTheme.dimensions.spaceM)
-            .testTag(StartTimeInfoSceneTestTag)
+            .testTag(PreparationTimeInfoSceneTestTag)
     ) {
         TempoText(
-            modifier = Modifier.testTag(StartTimeInfoTitleTestTag),
-            text = stringResource(id = R.string.label_routine_start_time_info_title),
+            modifier = Modifier.testTag(PreparationTimeInfoTitleTestTag),
+            text = stringResource(id = R.string.label_routine_preparation_time_info_title),
             style = TempoTheme.typography.h1
         )
         TempoText(
-            modifier = Modifier.testTag(StartTimeInfoDescriptionTestTag),
-            text = stringResource(id = R.string.label_routine_start_time_info_description),
+            modifier = Modifier.testTag(PreparationTimeInfoDescriptionTestTag),
+            text = stringResource(id = R.string.label_routine_preparation_time_info_description),
             style = TempoTheme.typography.body1
         )
     }

--- a/features/routines/src/main/java/com/enricog/features/routines/detail/routine/RoutineScreen.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/detail/routine/RoutineScreen.kt
@@ -22,8 +22,8 @@ internal fun RoutineScreen(viewModel: RoutineViewModel) {
         viewState.Compose(
             inputs = fieldInputs,
             onRoutineNameChange = viewModel::onRoutineNameTextChange,
-            onStartTimeOffsetChange = viewModel::onRoutineStartTimeOffsetChange,
-            onStartTimeInfo = viewModel::onRoutineStartTimeInfo,
+            onPreparationTimeChange = viewModel::onRoutinePreparationTimeChange,
+            onPreparationTimeInfo = viewModel::onRoutinePreparationTimeInfo,
             onRoutineSave = viewModel::onRoutineSave,
             onRetryLoad = viewModel::onRetryLoad,
             onSnackbarEvent = viewModel::onSnackbarEvent
@@ -35,8 +35,8 @@ internal fun RoutineScreen(viewModel: RoutineViewModel) {
 internal fun RoutineViewState.Compose(
     inputs: RoutineInputs,
     onRoutineNameChange: (TextFieldValue) -> Unit,
-    onStartTimeOffsetChange: (TimeText) -> Unit,
-    onStartTimeInfo: () -> Unit,
+    onPreparationTimeChange: (TimeText) -> Unit,
+    onPreparationTimeInfo: () -> Unit,
     onRoutineSave: () -> Unit,
     onRetryLoad: () -> Unit,
     onSnackbarEvent: (TempoSnackbarEvent) -> Unit
@@ -48,8 +48,8 @@ internal fun RoutineViewState.Compose(
             errors = errors,
             message = message,
             onRoutineNameChange = onRoutineNameChange,
-            onStartTimeOffsetChange = onStartTimeOffsetChange,
-            onStartTimeInfo = onStartTimeInfo,
+            onPreparationTimeChange = onPreparationTimeChange,
+            onPreparationTimeInfo = onPreparationTimeInfo,
             onRoutineSave = onRoutineSave,
             onSnackbarEvent = onSnackbarEvent
         )

--- a/features/routines/src/main/java/com/enricog/features/routines/detail/routine/RoutineViewModel.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/detail/routine/RoutineViewModel.kt
@@ -69,7 +69,7 @@ internal class RoutineViewModel @Inject constructor(
 
             fieldInputs = RoutineInputs(
                 name = routine.name.toTextFieldValue(),
-                startTimeOffset = routine.startTimeOffset.timeText
+                preparationTime = routine.preparationTime.timeText
             )
         }
     }
@@ -81,15 +81,15 @@ internal class RoutineViewModel @Inject constructor(
         }
     }
 
-    fun onRoutineStartTimeOffsetChange(text: TimeText) {
-        if (text.toSeconds() <= Routine.MAX_START_TIME_OFFSET) {
-            fieldInputs = fieldInputs.copy(startTimeOffset = text)
+    fun onRoutinePreparationTimeChange(text: TimeText) {
+        if (text.toSeconds() <= Routine.MAX_PREPARATION_TIME) {
+            fieldInputs = fieldInputs.copy(preparationTime = text)
         }
     }
 
-    fun onRoutineStartTimeInfo() {
+    fun onRoutinePreparationTimeInfo() {
         launch {
-            navigationActions.openRoutineStartTimeInfo()
+            navigationActions.openRoutinePreparationTimeInfo()
         }
     }
 

--- a/features/routines/src/main/java/com/enricog/features/routines/detail/routine/models/RoutineInputs.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/detail/routine/models/RoutineInputs.kt
@@ -8,20 +8,20 @@ import com.enricog.ui.components.textField.TimeText
 
 internal data class RoutineInputs(
     val name: TextFieldValue,
-    val startTimeOffset: TimeText
+    val preparationTime: TimeText
 ) {
 
     fun mergeToRoutine(routine: Routine): Routine {
         return routine.copy(
             name = name.text,
-            startTimeOffset = startTimeOffset.toSeconds()
+            preparationTime = preparationTime.toSeconds()
         )
     }
 
     companion object {
         val empty = RoutineInputs(
             name = "".toTextFieldValue(),
-            startTimeOffset = TimeText.from(0.seconds)
+            preparationTime = TimeText.from(0.seconds)
         )
     }
 }

--- a/features/routines/src/main/java/com/enricog/features/routines/detail/routine/ui_components/RoutineFormScene.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/detail/routine/ui_components/RoutineFormScene.kt
@@ -48,13 +48,13 @@ internal fun RoutineFormScene(
     errors: ImmutableMap<RoutineField, RoutineFieldError>,
     message: Message?,
     onRoutineNameChange: (TextFieldValue) -> Unit,
-    onStartTimeOffsetChange: (TimeText) -> Unit,
-    onStartTimeInfo: () -> Unit,
+    onPreparationTimeChange: (TimeText) -> Unit,
+    onPreparationTimeInfo: () -> Unit,
     onRoutineSave: () -> Unit,
     onSnackbarEvent: (TempoSnackbarEvent) -> Unit
 ) {
     val keyboardController = LocalSoftwareKeyboardController.current
-    val (routineNameRef, routineStartTimeRef) = remember { FocusRequester.createRefs() }
+    val (routineNameRef, routinePreparationTimeRef) = remember { FocusRequester.createRefs() }
     val scrollState = rememberScrollState(initial = 0)
     val snackbarHostState = rememberSnackbarHostState()
 
@@ -92,24 +92,24 @@ internal fun RoutineFormScene(
                         singleLine = true,
                         keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
                         keyboardActions = KeyboardActions(
-                            onNext = { routineStartTimeRef.requestFocus() }
+                            onNext = { routinePreparationTimeRef.requestFocus() }
                         )
                     )
 
                     TempoTimeField(
-                        value = inputs.startTimeOffset,
-                        onValueChange = onStartTimeOffsetChange,
+                        value = inputs.preparationTime,
+                        onValueChange = onPreparationTimeChange,
                         modifier = Modifier
                             .fillMaxWidth()
-                            .focusRequester(routineStartTimeRef),
-                        labelText = stringResource(R.string.field_label_routine_start_time_offset),
-                        supportingText = stringResource(R.string.field_support_text_routine_start_time_offset),
+                            .focusRequester(routinePreparationTimeRef),
+                        labelText = stringResource(R.string.field_label_routine_preparation_time),
+                        supportingText = stringResource(R.string.field_support_text_routine_preparation_time),
                         imeAction = ImeAction.Done,
                         keyboardActions = KeyboardActions(
                             onDone = { keyboardController?.hide() }
                         ),
                         trailingIcon = {
-                            StartTimeInfoIcon(onStartTimeInfo)
+                            PreparationTimeInfoIcon(onPreparationTimeInfo)
                         }
                     )
                 }
@@ -130,10 +130,10 @@ internal fun RoutineFormScene(
 }
 
 @Composable
-private fun StartTimeInfoIcon(onClick: () -> Unit) {
+private fun PreparationTimeInfoIcon(onClick: () -> Unit) {
     TempoIcon(
         iconResId = R.drawable.ic_routine_help,
-        contentDescription = stringResource(R.string.content_description_button_help_routine_start_time),
+        contentDescription = stringResource(R.string.content_description_button_help_routine_preparation_time),
         size = TempoIconSize.Original,
         color = TempoTheme.colors.onSurfaceSecondary,
         modifier = Modifier.clickable(

--- a/features/routines/src/main/java/com/enricog/features/routines/navigation/RoutinesNavigationActions.kt
+++ b/features/routines/src/main/java/com/enricog/features/routines/navigation/RoutinesNavigationActions.kt
@@ -5,8 +5,8 @@ import com.enricog.navigation.api.NavigationAction.GoBack
 import com.enricog.navigation.api.Navigator
 import com.enricog.navigation.api.routes.RoutineRoute
 import com.enricog.navigation.api.routes.RoutineRouteInput
-import com.enricog.navigation.api.routes.RoutineStartTimeInfoRoute
-import com.enricog.navigation.api.routes.RoutineStartTimeInfoRouteInput
+import com.enricog.navigation.api.routes.RoutinePreparationTimeInfoRoute
+import com.enricog.navigation.api.routes.RoutinePreparationTimeInfoRouteInput
 import com.enricog.navigation.api.routes.RoutineSummaryRoute
 import com.enricog.navigation.api.routes.RoutineSummaryRouteInput
 import com.enricog.navigation.api.routes.RoutinesRoute
@@ -63,9 +63,9 @@ internal class RoutinesNavigationActions @Inject constructor(
         navigator.navigate(routeNavigation)
     }
 
-    suspend fun openRoutineStartTimeInfo() {
-        val routeNavigation = RoutineStartTimeInfoRoute.navigate(
-            input = RoutineStartTimeInfoRouteInput,
+    suspend fun openRoutinePreparationTimeInfo() {
+        val routeNavigation = RoutinePreparationTimeInfoRoute.navigate(
+            input = RoutinePreparationTimeInfoRouteInput,
             optionsBuilder = null
         )
         navigator.navigate(routeNavigation)

--- a/features/routines/src/main/res/values/strings.xml
+++ b/features/routines/src/main/res/values/strings.xml
@@ -16,17 +16,17 @@
 
     <!-- Routine -->
     <string name="field_label_routine_name">Routine name</string>
-    <string name="field_label_routine_start_time_offset">Delay between each segment</string>
-    <string name="field_support_text_routine_start_time_offset">Max 1 minute</string>
+    <string name="field_label_routine_preparation_time">Preparation time</string>
+    <string name="field_support_text_routine_preparation_time">Max 1 minute</string>
     <string name="field_error_message_routine_name_blank">Routine name must not be blank</string>
     <string name="content_description_button_save_routine">Save routine</string>
-    <string name="content_description_button_help_routine_start_time">Info about start time</string>
+    <string name="content_description_button_help_routine_preparation_time">Info about preparation time</string>
     <string name="label_routine_save_error">An error happen</string>
     <string name="action_text_routine_save_error">Retry</string>
 
-    <!-- Start time -->
-    <string name="label_routine_start_time_info_title">What is this delay?</string>
-    <string name="label_routine_start_time_info_description">This is the amount of time between segments. This delay can be maximum 1 minutes. It can be used as a little timeout between segments.
+    <!-- Preparation time -->
+    <string name="label_routine_preparation_time_info_title">What is this delay?</string>
+    <string name="label_routine_preparation_time_info_description">This is the amount of time between segments. This delay can be maximum 1 minutes. It can be used a little preparation before starting a new segment.
         For example, if you setup a routine for your workout can be seen as the time you have to setup to start the next exercise.\nIf you need more you can create your own segment for that.\nYou can change this value whenever you want.
     </string>
 

--- a/features/routines/src/test/java/com/enricog/features/routines/detail/routine/RoutineReducerTest.kt
+++ b/features/routines/src/test/java/com/enricog/features/routines/detail/routine/RoutineReducerTest.kt
@@ -18,7 +18,7 @@ class RoutineReducerTest {
     fun `should setup state with routine`() {
         val routine = Routine.EMPTY.copy(
             name = "routine name",
-            startTimeOffset = 50.seconds
+            preparationTime = 50.seconds
         )
         val expected = RoutineState.Data(
             routine = routine,

--- a/features/routines/src/test/java/com/enricog/features/routines/detail/routine/RoutineValidatorTest.kt
+++ b/features/routines/src/test/java/com/enricog/features/routines/detail/routine/RoutineValidatorTest.kt
@@ -16,7 +16,7 @@ class RoutineValidatorTest {
     fun `should return error when routine name is blank`() {
         val inputs = RoutineInputs(
             name = "".toTextFieldValue(),
-            startTimeOffset = "".timeText
+            preparationTime = "".timeText
         )
         val expected: Map<RoutineField, RoutineFieldError> = mapOf(
             RoutineField.Name to RoutineFieldError.BlankRoutineName,

--- a/features/routines/src/test/java/com/enricog/features/routines/detail/routine/RoutineViewModelTest.kt
+++ b/features/routines/src/test/java/com/enricog/features/routines/detail/routine/RoutineViewModelTest.kt
@@ -38,7 +38,7 @@ class RoutineViewModelTest {
     private val routine = Routine.EMPTY.copy(
         id = 1.asID,
         name = "Routine Name",
-        startTimeOffset = 30.seconds,
+        preparationTime = 30.seconds,
         segments = emptyList()
     )
 
@@ -52,7 +52,7 @@ class RoutineViewModelTest {
         )
         val expectedFieldInputs = RoutineInputs(
             name = "Routine Name".toTextFieldValue(),
-            startTimeOffset = "30".timeText
+            preparationTime = "30".timeText
         )
 
         val viewModel = buildViewModel()
@@ -86,7 +86,7 @@ class RoutineViewModelTest {
         )
         val expectedFieldInputs = RoutineInputs(
             name = "Routine Name".toTextFieldValue(),
-            startTimeOffset = "30".timeText
+            preparationTime = "30".timeText
         )
         store.enableErrorOnNextAccess()
         val viewModel = buildViewModel(store = store)
@@ -109,7 +109,7 @@ class RoutineViewModelTest {
         )
         val expectedFieldInputs = RoutineInputs(
             name = "Routine Name Modified".toTextFieldValue(),
-            startTimeOffset = "30".timeText
+            preparationTime = "30".timeText
         )
         val viewModel = buildViewModel()
         advanceUntilIdle()
@@ -131,12 +131,12 @@ class RoutineViewModelTest {
         )
         val expectedFieldInputs = RoutineInputs(
             name = "Routine Name".toTextFieldValue(),
-            startTimeOffset = "10".timeText
+            preparationTime = "10".timeText
         )
         val viewModel = buildViewModel()
         advanceUntilIdle()
 
-        viewModel.onRoutineStartTimeOffsetChange(text = "10".timeText)
+        viewModel.onRoutinePreparationTimeChange(text = "10".timeText)
         advanceUntilIdle()
 
         viewModel.viewState.test {
@@ -153,12 +153,12 @@ class RoutineViewModelTest {
         )
         val expectedFieldInputs = RoutineInputs(
             name = "Routine Name".toTextFieldValue(),
-            startTimeOffset = "30".timeText
+            preparationTime = "30".timeText
         )
         val viewModel = buildViewModel()
         advanceUntilIdle()
 
-        viewModel.onRoutineStartTimeOffsetChange(text = "3000".timeText)
+        viewModel.onRoutinePreparationTimeChange(text = "3000".timeText)
         advanceUntilIdle()
 
         viewModel.viewState.test {
@@ -212,7 +212,7 @@ class RoutineViewModelTest {
         store.get().first().let { actual ->
             assertThat(actual.name).isEqualTo(expectedViewState.name)
             assertThat(actual.segments).isEqualTo(expectedViewState.segments)
-            assertThat(actual.startTimeOffset).isEqualTo(expectedViewState.startTimeOffset)
+            assertThat(actual.preparationTime).isEqualTo(expectedViewState.preparationTime)
 
             navigator.assertGoTo(
                 route = RoutineSummaryRoute,

--- a/features/routines/src/test/java/com/enricog/features/routines/detail/routine/usecase/RoutineUseCaseTest.kt
+++ b/features/routines/src/test/java/com/enricog/features/routines/detail/routine/usecase/RoutineUseCaseTest.kt
@@ -32,7 +32,7 @@ class RoutineUseCaseTest {
 
             assertThat(actual.id).isEqualTo(expected.id)
             assertThat(actual.name).isEqualTo(expected.name)
-            assertThat(actual.startTimeOffset).isEqualTo(expected.startTimeOffset)
+            assertThat(actual.preparationTime).isEqualTo(expected.preparationTime)
             assertThat(actual.segments).isEqualTo(expected.segments)
             assertThat(actual.rank).isEqualTo(expected.rank)
         }
@@ -60,7 +60,7 @@ class RoutineUseCaseTest {
 
             assertThat(actual.id).isEqualTo(expected.id)
             assertThat(actual.name).isEqualTo(expected.name)
-            assertThat(actual.startTimeOffset).isEqualTo(expected.startTimeOffset)
+            assertThat(actual.preparationTime).isEqualTo(expected.preparationTime)
             assertThat(actual.segments).isEqualTo(expected.segments)
             assertThat(actual.rank).isEqualTo(expected.rank)
         }
@@ -87,7 +87,7 @@ class RoutineUseCaseTest {
         store.get().first().let { createdRoutine ->
             assertThat(actual).isEqualTo(createdRoutine.id)
             assertThat(createdRoutine.name).isEqualTo(routine.name)
-            assertThat(createdRoutine.startTimeOffset).isEqualTo(routine.startTimeOffset)
+            assertThat(createdRoutine.preparationTime).isEqualTo(routine.preparationTime)
             assertThat(createdRoutine.segments).isEqualTo(routine.segments)
             assertThat(createdRoutine.rank).isEqualTo(routine.rank)
         }

--- a/features/timer/src/main/java/com/enricog/features/timer/TimerReducer.kt
+++ b/features/timer/src/main/java/com/enricog/features/timer/TimerReducer.kt
@@ -20,11 +20,11 @@ internal class TimerReducer @Inject constructor() {
             val getNextId = generateId()
 
             for (segment in routine.segments) {
-                if (segment.type.requirePreparationTime && routine.startTimeOffset > 0.seconds) {
+                if (segment.type.requirePreparationTime && routine.preparationTime > 0.seconds) {
                     add(
                         SegmentStep(
                             id = getNextId(),
-                            count = Count.idle(seconds = routine.startTimeOffset),
+                            count = Count.idle(seconds = routine.preparationTime),
                             type = SegmentStepType.STARTING,
                             segment = segment
                         )
@@ -99,7 +99,7 @@ internal class TimerReducer @Inject constructor() {
         if (state !is TimerState.Counting) return state
 
         val currentResetTime = when (state.runningStep.type) {
-            SegmentStepType.STARTING -> state.routine.startTimeOffset
+            SegmentStepType.STARTING -> state.routine.preparationTime
             SegmentStepType.IN_PROGRESS -> state.runningSegment.time
         }
 

--- a/features/timer/src/test/java/com/enricog/features/timer/TimerReducerTest.kt
+++ b/features/timer/src/test/java/com/enricog/features/timer/TimerReducerTest.kt
@@ -17,9 +17,9 @@ class TimerReducerTest {
     private val timerReducer = TimerReducer()
 
     @Test
-    fun `should setup state with starting segment when start timer offset is more than 0`() {
+    fun `should setup state with starting segment when preparation is more than 0`() {
         val routine = Routine.EMPTY.copy(
-            startTimeOffset = 5.seconds,
+            preparationTime = 5.seconds,
             segments = listOf(
                 Segment.EMPTY.copy(name = "segment name stopwatch", type = TimeType.STOPWATCH),
                 Segment.EMPTY.copy(
@@ -105,9 +105,9 @@ class TimerReducerTest {
     }
 
     @Test
-    fun `should setup state with segment in progress when start timer offset is 0`() {
+    fun `should setup state with segment in progress when preparation time is 0`() {
         val routine = Routine.EMPTY.copy(
-            startTimeOffset = 0.seconds,
+            preparationTime = 0.seconds,
             segments = listOf(
                 Segment.EMPTY.copy(name = "segment name stopwatch", type = TimeType.STOPWATCH),
                 Segment.EMPTY.copy(
@@ -177,7 +177,7 @@ class TimerReducerTest {
     fun `should setup state with same sound enable status when current state is counting`() {
         val segment = Segment.EMPTY.copy(time = 5.seconds)
         val routine = Routine.EMPTY.copy(
-            startTimeOffset = 0.seconds,
+            preparationTime = 0.seconds,
             segments = listOf(segment)
         )
         val state = TimerState.Counting(
@@ -355,7 +355,7 @@ class TimerReducerTest {
     @Test
     fun `should update state by completing the step on progressing time when a starting segment is running and count reach zero`() {
         val segment = Segment.EMPTY.copy(type = TimeType.TIMER, time = 10.seconds)
-        val routine = Routine.EMPTY.copy(segments = listOf(segment), startTimeOffset = 5.seconds)
+        val routine = Routine.EMPTY.copy(segments = listOf(segment), preparationTime = 5.seconds)
         val state = TimerState.Counting(
             routine = routine,
             runningStep = SegmentStep(
@@ -717,7 +717,7 @@ class TimerReducerTest {
     @Test
     fun `should update state by running the previous step on jump step back when segment count is in the initial value`() {
         val segment = Segment.EMPTY.copy(time = 10.seconds, type = TimeType.TIMER)
-        val routine = Routine.EMPTY.copy(segments = listOf(segment), startTimeOffset = 5.seconds)
+        val routine = Routine.EMPTY.copy(segments = listOf(segment), preparationTime = 5.seconds)
         val state = TimerState.Counting(
             routine = routine,
             runningStep = SegmentStep(
@@ -775,7 +775,7 @@ class TimerReducerTest {
     @Test
     fun `should update state by running the next step on jump step next when there is a next step`() {
         val segment = Segment.EMPTY.copy(time = 10.seconds, type = TimeType.TIMER)
-        val routine = Routine.EMPTY.copy(segments = listOf(segment), startTimeOffset = 5.seconds)
+        val routine = Routine.EMPTY.copy(segments = listOf(segment), preparationTime = 5.seconds)
         val state = TimerState.Counting(
             routine = routine,
             runningStep = SegmentStep(
@@ -833,7 +833,7 @@ class TimerReducerTest {
     @Test
     fun `should update state by setting running step as completed on jump step next when there is not a next step`() {
         val segment = Segment.EMPTY.copy(time = 10.seconds, type = TimeType.TIMER)
-        val routine = Routine.EMPTY.copy(segments = listOf(segment), startTimeOffset = 5.seconds)
+        val routine = Routine.EMPTY.copy(segments = listOf(segment), preparationTime = 5.seconds)
         val state = TimerState.Counting(
             routine = routine,
             runningStep = SegmentStep(
@@ -919,7 +919,7 @@ class TimerReducerTest {
     @Test
     fun `should update state with new segment on next step`() {
         val segment = Segment.EMPTY.copy(time = 10.seconds, type = TimeType.TIMER)
-        val routine = Routine.EMPTY.copy(segments = listOf(segment), startTimeOffset = 5.seconds)
+        val routine = Routine.EMPTY.copy(segments = listOf(segment), preparationTime = 5.seconds)
         val state = TimerState.Counting(
             routine = routine,
             runningStep = SegmentStep(

--- a/features/timer/src/test/java/com/enricog/features/timer/TimerStateConverterTest.kt
+++ b/features/timer/src/test/java/com/enricog/features/timer/TimerStateConverterTest.kt
@@ -330,7 +330,7 @@ class TimerStateConverterTest {
         coroutineRule {
             val state = TimerState.Counting(
                 routine =  Routine.EMPTY.copy(
-                    startTimeOffset = 5.seconds,
+                    preparationTime = 5.seconds,
                     segments = listOf(
                         Segment.EMPTY.copy(name = "segment name", type = TimeType.STOPWATCH)
                     )
@@ -395,7 +395,7 @@ class TimerStateConverterTest {
         coroutineRule {
             val state = TimerState.Counting(
                 routine =  Routine.EMPTY.copy(
-                    startTimeOffset = 5.seconds,
+                    preparationTime = 5.seconds,
                     segments = listOf(
                         Segment.EMPTY.copy(name = "segment name stopwatch", type = TimeType.STOPWATCH),
                         Segment.EMPTY.copy(name = "segment name timer", type = TimeType.TIMER)

--- a/features/timer/src/test/java/com/enricog/features/timer/TimerViewModelTest.kt
+++ b/features/timer/src/test/java/com/enricog/features/timer/TimerViewModelTest.kt
@@ -50,7 +50,7 @@ class TimerViewModelTest {
     private val routine = Routine.EMPTY.copy(
         id = 1.asID,
         segments = listOf(firstSegment, secondSegment),
-        startTimeOffset = 3.seconds
+        preparationTime = 3.seconds
     )
 
     private val navigator = FakeNavigator()

--- a/features/timer/src/test/java/com/enricog/features/timer/models/TimerStateTest.kt
+++ b/features/timer/src/test/java/com/enricog/features/timer/models/TimerStateTest.kt
@@ -14,7 +14,7 @@ internal class TimerStateTest {
     private val count = Count(seconds = 10.seconds, isRunning = true, isCompleted = false)
     private val state = TimerState.Counting(
         routine = Routine.EMPTY.copy(
-            startTimeOffset = 10.seconds,
+            preparationTime = 10.seconds,
             segments = listOf(
                 Segment.EMPTY.copy(id = 1.asID, type = TimeType.TIMER),
                 Segment.EMPTY.copy(id = 2.asID, type = TimeType.STOPWATCH)

--- a/navigation/api/src/main/java/com/enricog/navigation/api/routes/RoutinePreparationTimeInfoRoute.kt
+++ b/navigation/api/src/main/java/com/enricog/navigation/api/routes/RoutinePreparationTimeInfoRoute.kt
@@ -9,9 +9,9 @@ import androidx.navigation.navOptions
 import com.enricog.navigation.api.NavigationAction
 import com.enricog.navigation.api.extensions.bottomSheet
 
-object RoutineStartTimeInfoRoute : Route<RoutineStartTimeInfoRouteInput> {
+object RoutinePreparationTimeInfoRoute : Route<RoutinePreparationTimeInfoRouteInput> {
 
-    override val name: String = "routine/start-time-info"
+    override val name: String = "routine/preparation-time-info"
 
     override fun NavGraphBuilder.compose(content: @Composable (NavBackStackEntry) -> Unit) {
         bottomSheet(
@@ -21,16 +21,16 @@ object RoutineStartTimeInfoRoute : Route<RoutineStartTimeInfoRouteInput> {
     }
 
     override fun navigate(
-        input: RoutineStartTimeInfoRouteInput,
+        input: RoutinePreparationTimeInfoRouteInput,
         optionsBuilder: (NavOptionsBuilder.() -> Unit)?
     ): NavigationAction {
         val options = optionsBuilder?.let { navOptions(it) }
         return NavigationAction.GoTo(route = name, navOptions = options)
     }
 
-    override fun extractInput(savedStateHandle: SavedStateHandle): RoutineStartTimeInfoRouteInput {
-        return RoutineStartTimeInfoRouteInput
+    override fun extractInput(savedStateHandle: SavedStateHandle): RoutinePreparationTimeInfoRouteInput {
+        return RoutinePreparationTimeInfoRouteInput
     }
 }
 
-object RoutineStartTimeInfoRouteInput : RouteInput
+object RoutinePreparationTimeInfoRouteInput : RouteInput

--- a/navigation/api/src/test/java/com/enricog/navigation/api/routes/RoutinePreparationTimeInfoRouteTest.kt
+++ b/navigation/api/src/test/java/com/enricog/navigation/api/routes/RoutinePreparationTimeInfoRouteTest.kt
@@ -6,27 +6,27 @@ import com.enricog.navigation.api.NavigationAction
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 
-class RoutineStartTimeInfoRouteTest {
+class RoutinePreparationTimeInfoRouteTest {
 
     @Test
     fun `test name`() {
-        val expected = "routine/start-time-info"
+        val expected = "routine/preparation-time-info"
 
-        val actual = RoutineStartTimeInfoRoute.name
+        val actual = RoutinePreparationTimeInfoRoute.name
 
         assertThat(actual).isEqualTo(expected)
     }
 
     @Test
     fun `test navigate`() {
-        val input = RoutineStartTimeInfoRouteInput
+        val input = RoutinePreparationTimeInfoRouteInput
         val navOptions = navOptions {}
         val expected = NavigationAction.GoTo(
-            route = "routine/start-time-info",
+            route = "routine/preparation-time-info",
             navOptions = navOptions
         )
 
-        val actual = RoutineStartTimeInfoRoute.navigate(input = input, optionsBuilder = {})
+        val actual = RoutinePreparationTimeInfoRoute.navigate(input = input, optionsBuilder = {})
 
         assertThat(actual).isEqualTo(expected)
     }
@@ -34,9 +34,9 @@ class RoutineStartTimeInfoRouteTest {
     @Test
     fun `test extractInput`() {
         val savedStateHandle = SavedStateHandle(emptyMap())
-        val expected = RoutineStartTimeInfoRouteInput
+        val expected = RoutinePreparationTimeInfoRouteInput
 
-        val actual = RoutineStartTimeInfoRoute.extractInput(savedStateHandle = savedStateHandle)
+        val actual = RoutinePreparationTimeInfoRoute.extractInput(savedStateHandle = savedStateHandle)
 
         assertThat(actual).isEqualTo(expected)
     }


### PR DESCRIPTION
Rename routine start time to preparation time.
This should make more clear what this time is about.

**Note**: the command `ALTER TABLE table RENAME COLUMN oldname TO newname` cannot be used since it was supported from SQLlite version [3.25.0](https://www.sqlite.org/changes.html). 
Phones with android 10 or lower run an older version of SQLlite which makes the command fail.
For this reason has been used a manual procedure to rename a table column