### PR TITLE
Feature: Keep screen on setting

### DIFF
--- a/data/local/database/src/androidTest/java/com/enricog/data/local/database/timer/settings/TimerSettingsDataSourceImplTest.kt
+++ b/data/local/database/src/androidTest/java/com/enricog/data/local/database/timer/settings/TimerSettingsDataSourceImplTest.kt
@@ -52,6 +52,7 @@ internal class TimerSettingsDataSourceImplTest {
     @Test
     fun shouldReturnDefaultSettingsWhenThereIsNoStoredData() = coroutineRule {
         val expected = TimerSettings(
+            keepScreenOnEnabled = true,
             soundEnabled = true,
             runInBackgroundEnabled = false
         )
@@ -64,10 +65,12 @@ internal class TimerSettingsDataSourceImplTest {
     @Test
     fun shouldReturnStoredSettingsWhenThereIsStoredData() = coroutineRule {
         testDataStore.edit { preferences ->
+            preferences[booleanPreferencesKey(name = "keep_screen_on_enabled")] = false
             preferences[booleanPreferencesKey(name = "sound_enabled")] = false
             preferences[booleanPreferencesKey(name = "run_in_background_enabled")] = true
         }
         val expected = TimerSettings(
+            keepScreenOnEnabled = false,
             soundEnabled = false,
             runInBackgroundEnabled = true
         )
@@ -80,14 +83,17 @@ internal class TimerSettingsDataSourceImplTest {
     @Test
     fun shouldUpdateStoredSettings() = coroutineRule {
         testDataStore.edit { preferences ->
+            preferences[booleanPreferencesKey(name = "keep_screen_on_enabled")] = false
             preferences[booleanPreferencesKey(name = "sound_enabled")] = false
             preferences[booleanPreferencesKey(name = "run_in_background_enabled")] = false
         }
         val settings = TimerSettings(
+            keepScreenOnEnabled = true,
             soundEnabled = true,
             runInBackgroundEnabled = true
         )
         val expected = preferencesOf(
+            booleanPreferencesKey(name = "keep_screen_on_enabled") to true,
             booleanPreferencesKey(name = "sound_enabled") to true,
             booleanPreferencesKey(name = "run_in_background_enabled") to true
         )

--- a/data/local/database/src/main/java/com/enricog/data/local/database/timer/settings/TimerSettingsDataSourceImpl.kt
+++ b/data/local/database/src/main/java/com/enricog/data/local/database/timer/settings/TimerSettingsDataSourceImpl.kt
@@ -17,6 +17,7 @@ internal class TimerSettingsDataSourceImpl @Inject constructor(
     private val dataStore: DataStore<Preferences>
 ) : TimerSettingsDataSource {
 
+    private val keepScreenOnEnabledKey = booleanPreferencesKey(KEEP_SCREEN_ON_ENABLED_PREF_NAME)
     private val soundEnabledKey = booleanPreferencesKey(SOUND_ENABLED_PREF_NAME)
     private val runInBackgroundEnabledKey = booleanPreferencesKey(RUN_IN_BACKGROUND_ENABLED_PREF_NAME)
 
@@ -36,6 +37,7 @@ internal class TimerSettingsDataSourceImpl @Inject constructor(
 
     override suspend fun update(settings: TimerSettings) {
         dataStore.edit { preferences ->
+            preferences[keepScreenOnEnabledKey] = settings.keepScreenOnEnabled
             preferences[soundEnabledKey] = settings.soundEnabled
             preferences[runInBackgroundEnabledKey] = settings.runInBackgroundEnabled
         }
@@ -43,12 +45,14 @@ internal class TimerSettingsDataSourceImpl @Inject constructor(
 
     private fun Preferences.toTimerSettings(): TimerSettings {
         return TimerSettings(
+            keepScreenOnEnabled = this[keepScreenOnEnabledKey] ?: true,
             soundEnabled = this[soundEnabledKey] ?: true,
             runInBackgroundEnabled = this[runInBackgroundEnabledKey] ?: false
         )
     }
 
     private companion object {
+        const val KEEP_SCREEN_ON_ENABLED_PREF_NAME = "keep_screen_on_enabled"
         const val SOUND_ENABLED_PREF_NAME = "sound_enabled"
         const val RUN_IN_BACKGROUND_ENABLED_PREF_NAME = "run_in_background_enabled"
     }

--- a/data/timer/api/src/main/java/com/enricog/data/timer/api/settings/entities/TimerSettings.kt
+++ b/data/timer/api/src/main/java/com/enricog/data/timer/api/settings/entities/TimerSettings.kt
@@ -1,6 +1,7 @@
 package com.enricog.data.timer.api.settings.entities
 
 data class TimerSettings(
+    val keepScreenOnEnabled: Boolean,
     val soundEnabled: Boolean,
     val runInBackgroundEnabled: Boolean
 ) {

--- a/data/timer/testing/src/main/java/com/enricog/data/timer/testing/settings/entities/TimerSettingExtensions.kt
+++ b/data/timer/testing/src/main/java/com/enricog/data/timer/testing/settings/entities/TimerSettingExtensions.kt
@@ -4,6 +4,7 @@ import com.enricog.data.timer.api.settings.entities.TimerSettings
 
 val TimerSettings.Companion.DEFAULT: TimerSettings
     get() = TimerSettings(
+        keepScreenOnEnabled = true,
         soundEnabled = true,
         runInBackgroundEnabled = false
     )

--- a/features/timer/src/androidTest/java/com/enricog/features/timer/settings/ui_components/TimerSettingsSceneKtTest.kt
+++ b/features/timer/src/androidTest/java/com/enricog/features/timer/settings/ui_components/TimerSettingsSceneKtTest.kt
@@ -17,8 +17,54 @@ internal class TimerSettingsSceneKtTest {
     val composeTestRule = createComposeRule()
 
     @Test
+    fun shouldShowSettingsWithKeepScreenOnEnabled() = composeTestRule {
+        val viewState = TimerSettingsViewState.Data(
+            keepScreenOnSetting = TimerSettingsViewState.Data.Setting(
+                title = R.string.label_routine_settings_keep_screen_on,
+                enabled = true
+            ),
+            soundSetting = TimerSettingsViewState.Data.Setting(
+                title = R.string.label_routine_settings_sound,
+                enabled = false
+            ),
+            runInBackgroundSetting = TimerSettingsViewState.Data.Setting(
+                title = R.string.label_routine_settings_background,
+                enabled = false
+            )
+        )
+
+        setContent {
+            TempoTheme {
+                TimerSettingsScene(
+                    state = viewState,
+                    onKeepScreenOnClick = {},
+                    onSoundClick = {},
+                    onRunInBackgroundClick = {}
+                )
+            }
+        }
+
+        onNodeWithTag(TimerKeepScreenOnSettingButtonTestTag).apply {
+            assertIsDisplayed()
+            assertChecked(checked = true)
+        }
+        onNodeWithTag(TimerSoundSettingButtonTestTag).apply {
+            assertIsDisplayed()
+            assertChecked(checked = false)
+        }
+        onNodeWithTag(TimerBackgroundSettingButtonTestTag).apply {
+            assertIsDisplayed()
+            assertChecked(checked = false)
+        }
+    }
+
+    @Test
     fun shouldShowSettingsWithSoundEnabled() = composeTestRule {
         val viewState = TimerSettingsViewState.Data(
+            keepScreenOnSetting = TimerSettingsViewState.Data.Setting(
+                title = R.string.label_routine_settings_keep_screen_on,
+                enabled = false
+            ),
             soundSetting = TimerSettingsViewState.Data.Setting(
                 title = R.string.label_routine_settings_sound,
                 enabled = true
@@ -33,12 +79,17 @@ internal class TimerSettingsSceneKtTest {
             TempoTheme {
                 TimerSettingsScene(
                     state = viewState,
+                    onKeepScreenOnClick = {},
                     onSoundClick = {},
                     onRunInBackgroundClick = {}
                 )
             }
         }
 
+        onNodeWithTag(TimerKeepScreenOnSettingButtonTestTag).apply {
+            assertIsDisplayed()
+            assertChecked(checked = false)
+        }
         onNodeWithTag(TimerSoundSettingButtonTestTag).apply {
             assertIsDisplayed()
             assertChecked(checked = true)
@@ -52,6 +103,10 @@ internal class TimerSettingsSceneKtTest {
     @Test
     fun shouldShowSettingsWithRunInBackgroundEnabled() = composeTestRule {
         val viewState = TimerSettingsViewState.Data(
+            keepScreenOnSetting = TimerSettingsViewState.Data.Setting(
+                title = R.string.label_routine_settings_keep_screen_on,
+                enabled = false
+            ),
             soundSetting = TimerSettingsViewState.Data.Setting(
                 title = R.string.label_routine_settings_sound,
                 enabled = false
@@ -66,12 +121,17 @@ internal class TimerSettingsSceneKtTest {
             TempoTheme {
                 TimerSettingsScene(
                     state = viewState,
+                    onKeepScreenOnClick = {},
                     onSoundClick = {},
                     onRunInBackgroundClick = {}
                 )
             }
         }
 
+        onNodeWithTag(TimerKeepScreenOnSettingButtonTestTag).apply {
+            assertIsDisplayed()
+            assertChecked(checked = false)
+        }
         onNodeWithTag(TimerSoundSettingButtonTestTag).apply {
             assertIsDisplayed()
             assertChecked(checked = false)

--- a/features/timer/src/main/java/com/enricog/features/timer/TimerViewModel.kt
+++ b/features/timer/src/main/java/com/enricog/features/timer/TimerViewModel.kt
@@ -127,7 +127,9 @@ internal class TimerViewModel @Inject constructor(
 
     private fun toggleKeepScreenOn(currentState: TimerState) {
         val enableKeepScreenOn = currentState is TimerState.Counting &&
-            currentState.isStepCountRunning && !currentState.isRoutineCompleted
+            currentState.isStepCountRunning &&
+            !currentState.isRoutineCompleted &&
+            currentState.timerSettings.keepScreenOnEnabled
         windowScreenManager.toggleKeepScreenOnFlag(enableKeepScreenOn)
     }
 

--- a/features/timer/src/main/java/com/enricog/features/timer/settings/TimerSettingsScreen.kt
+++ b/features/timer/src/main/java/com/enricog/features/timer/settings/TimerSettingsScreen.kt
@@ -28,6 +28,7 @@ internal fun TimerSettingsScreen(viewModel: TimerSettingsViewModel) {
             .padding(TempoTheme.dimensions.spaceM)
     ) {
         viewState.Compose(
+            onKeepScreenOnClick = viewModel::onToggleKeepScreenOn,
             onSoundClick = viewModel::onToggleSound,
             onRunInBackgroundClick = viewModel::onToggleRunInBackground
         )
@@ -36,6 +37,7 @@ internal fun TimerSettingsScreen(viewModel: TimerSettingsViewModel) {
 
 @Composable
 internal fun TimerSettingsViewState.Compose(
+    onKeepScreenOnClick: () -> Unit,
     onSoundClick: () -> Unit,
     onRunInBackgroundClick: () -> Unit
 ) {
@@ -43,6 +45,7 @@ internal fun TimerSettingsViewState.Compose(
         TimerSettingsViewState.Idle -> Unit
         is TimerSettingsViewState.Data -> TimerSettingsScene(
             state = this,
+            onKeepScreenOnClick = onKeepScreenOnClick,
             onSoundClick = onSoundClick,
             onRunInBackgroundClick = onRunInBackgroundClick
         )

--- a/features/timer/src/main/java/com/enricog/features/timer/settings/TimerSettingsStateConverter.kt
+++ b/features/timer/src/main/java/com/enricog/features/timer/settings/TimerSettingsStateConverter.kt
@@ -18,6 +18,10 @@ internal class TimerSettingsStateConverter @Inject constructor(
 
     private fun mapData(state: TimerSettingsState.Data): TimerSettingsViewState.Data {
         return TimerSettingsViewState.Data(
+            keepScreenOnSetting = TimerSettingsViewState.Data.Setting(
+                title = R.string.label_routine_settings_keep_screen_on,
+                enabled = state.timerSettings.keepScreenOnEnabled
+            ),
             soundSetting = TimerSettingsViewState.Data.Setting(
                 title = R.string.label_routine_settings_sound,
                 enabled = state.timerSettings.soundEnabled

--- a/features/timer/src/main/java/com/enricog/features/timer/settings/TimerSettingsViewModel.kt
+++ b/features/timer/src/main/java/com/enricog/features/timer/settings/TimerSettingsViewModel.kt
@@ -35,6 +35,15 @@ internal class TimerSettingsViewModel @Inject constructor(
             .launchIn(viewModelScope)
     }
 
+    fun onToggleKeepScreenOn() {
+        launchWhen<TimerSettingsState.Data> { state ->
+            val updatedSettings = state.timerSettings.copy(
+                keepScreenOnEnabled = !state.timerSettings.keepScreenOnEnabled
+            )
+            updateTimerSettingsUseCase(settings = updatedSettings)
+        }
+    }
+
     fun onToggleSound() {
         launchWhen<TimerSettingsState.Data> { state ->
             val updatedSettings = state.timerSettings.copy(

--- a/features/timer/src/main/java/com/enricog/features/timer/settings/models/TimerSettingsViewState.kt
+++ b/features/timer/src/main/java/com/enricog/features/timer/settings/models/TimerSettingsViewState.kt
@@ -7,6 +7,7 @@ internal sealed class TimerSettingsViewState {
     object Idle : TimerSettingsViewState()
 
     data class Data(
+        val keepScreenOnSetting: Setting,
         val soundSetting: Setting,
         val runInBackgroundSetting: Setting
     ): TimerSettingsViewState() {

--- a/features/timer/src/main/java/com/enricog/features/timer/settings/ui_components/TimerSettingsScene.kt
+++ b/features/timer/src/main/java/com/enricog/features/timer/settings/ui_components/TimerSettingsScene.kt
@@ -12,20 +12,45 @@ import com.enricog.ui.components.selector.TempoSwitch
 import com.enricog.ui.components.text.TempoText
 
 internal const val TimerSettingSceneTestTag = "TimerSettingSceneTestTag"
+internal const val TimerKeepScreenOnSettingButtonTestTag = "TimerKeepScreenOnSettingButtonTestTag"
 internal const val TimerSoundSettingButtonTestTag = "TimerSoundSettingButtonTestTag"
 internal const val TimerBackgroundSettingButtonTestTag = "TimerBackgroundSettingButtonTestTag"
 
 @Composable
 internal fun TimerSettingsScene(
     state: TimerSettingsViewState.Data,
+    onKeepScreenOnClick: () -> Unit,
     onSoundClick: () -> Unit,
     onRunInBackgroundClick: () -> Unit
 ) {
     Column(
         modifier = Modifier.testTag(TimerSettingSceneTestTag)
     ) {
+        KeepScreenOnSetting(keepScreenOnSetting = state.keepScreenOnSetting, onClick = onKeepScreenOnClick)
         SoundSetting(soundSetting = state.soundSetting, onClick = onSoundClick)
         BackgroundSetting(runInBackgroundSetting = state.runInBackgroundSetting, onClick = onRunInBackgroundClick)
+    }
+}
+
+@Composable
+private fun KeepScreenOnSetting(
+    keepScreenOnSetting: TimerSettingsViewState.Data.Setting,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        TempoText(
+            modifier = Modifier.weight(weight = 1f),
+            text = stringResource(id = keepScreenOnSetting.title)
+        )
+        TempoSwitch(
+            modifier = Modifier.testTag(TimerKeepScreenOnSettingButtonTestTag),
+            checked = keepScreenOnSetting.enabled,
+            onCheckedChange = { onClick() }
+        )
     }
 }
 

--- a/features/timer/src/main/res/values/strings.xml
+++ b/features/timer/src/main/res/values/strings.xml
@@ -10,6 +10,7 @@
 
     <string name="label_routine_total_time">Total time</string>
     <string name="label_routine_skip_count">N° skips</string>
+    <string name="label_routine_settings_keep_screen_on">Keep screen on</string>
     <string name="label_routine_settings_sound">Play sounds</string>
     <string name="label_routine_settings_background">Run in background</string>
 

--- a/features/timer/src/test/java/com/enricog/features/timer/TimerViewModelTest.kt
+++ b/features/timer/src/test/java/com/enricog/features/timer/TimerViewModelTest.kt
@@ -166,31 +166,8 @@ internal class TimerViewModelTest {
             runCurrent()
 
             assertThat(expectMostRecentItem()).isEqualTo(expected)
-            windowScreenManager.keepScreenOn.test {
-                assertThat(awaitItem()).isFalse()
-            }
             cancelAndIgnoreRemainingEvents()
         }
-    }
-
-    @Test
-    fun `should start service when timer is counting and run in background setting is enabled`() = coroutineRule {
-        timerSettingsStore.put(TimerSettings.DEFAULT.copy(runInBackgroundEnabled = true))
-
-        buildViewModel()
-        runCurrent()
-
-        timerServiceHandler.assertServiceIsStarted()
-    }
-
-    @Test
-    fun `should not start service when run in background setting is disabled`() = coroutineRule {
-        timerSettingsStore.put(TimerSettings.DEFAULT.copy(runInBackgroundEnabled = false))
-
-        buildViewModel()
-        runCurrent()
-
-        timerServiceHandler.assertServiceIsNotStarted()
     }
 
     @Test
@@ -294,6 +271,50 @@ internal class TimerViewModelTest {
     }
 
     @Test
+    fun `should keep screen on when keep screen on setting is enabled`() = coroutineRule {
+        timerSettingsStore.put(timerSettings.copy(keepScreenOnEnabled = true))
+        val viewModel = buildViewModel()
+
+        viewModel.viewState.test {
+            // Load
+            runCurrent()
+            // Start
+            advanceTimeBy(1000)
+            runCurrent()
+            // Advance count time 1 second
+            advanceTimeBy(1000)
+            runCurrent()
+
+            windowScreenManager.keepScreenOn.test {
+                assertThat(expectMostRecentItem()).isTrue()
+            }
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `should not keep screen on when keep screen on setting is disabled`() = coroutineRule {
+        timerSettingsStore.put(timerSettings.copy(keepScreenOnEnabled = false))
+        val viewModel = buildViewModel()
+
+        viewModel.viewState.test {
+            // Load
+            runCurrent()
+            // Start
+            advanceTimeBy(1000)
+            runCurrent()
+            // Advance count time 1 second
+            advanceTimeBy(1000)
+            runCurrent()
+
+            windowScreenManager.keepScreenOn.test {
+                assertThat(expectMostRecentItem()).isFalse()
+            }
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
     fun `should play sounds when segment count is completing and sound is enabled`() = coroutineRule {
         val viewModel = buildViewModel()
 
@@ -384,6 +405,25 @@ internal class TimerViewModelTest {
         }
     }
 
+    @Test
+    fun `should start service when timer is counting and run in background setting is enabled`() = coroutineRule {
+        timerSettingsStore.put(TimerSettings.DEFAULT.copy(runInBackgroundEnabled = true))
+
+        buildViewModel()
+        runCurrent()
+
+        timerServiceHandler.assertServiceIsStarted()
+    }
+
+    @Test
+    fun `should not start service when run in background setting is disabled`() = coroutineRule {
+        timerSettingsStore.put(TimerSettings.DEFAULT.copy(runInBackgroundEnabled = false))
+
+        buildViewModel()
+        runCurrent()
+
+        timerServiceHandler.assertServiceIsNotStarted()
+    }
 
     @Test
     fun `should go to routines on done`() = coroutineRule {

--- a/features/timer/src/test/java/com/enricog/features/timer/settings/TimerSettingsStateConverterTest.kt
+++ b/features/timer/src/test/java/com/enricog/features/timer/settings/TimerSettingsStateConverterTest.kt
@@ -33,6 +33,10 @@ internal class TimerSettingsStateConverterTest {
             timerSettings = TimerSettings.DEFAULT
         )
         val expected = TimerSettingsViewState.Data(
+            keepScreenOnSetting = TimerSettingsViewState.Data.Setting(
+                title = R.string.label_routine_settings_keep_screen_on,
+                enabled = state.timerSettings.keepScreenOnEnabled
+            ),
             soundSetting = TimerSettingsViewState.Data.Setting(
                 title = R.string.label_routine_settings_sound,
                 enabled = state.timerSettings.soundEnabled

--- a/features/timer/src/test/java/com/enricog/features/timer/settings/TimerSettingsViewModelTest.kt
+++ b/features/timer/src/test/java/com/enricog/features/timer/settings/TimerSettingsViewModelTest.kt
@@ -17,7 +17,6 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 
-
 internal class TimerSettingsViewModelTest {
 
     @get:Rule
@@ -36,6 +35,10 @@ internal class TimerSettingsViewModelTest {
     @Test
     fun `should get initial settings state`() = coroutineRule {
         val expected = TimerSettingsViewState.Data(
+            keepScreenOnSetting = TimerSettingsViewState.Data.Setting(
+                title = R.string.label_routine_settings_keep_screen_on,
+                enabled = true
+            ),
             soundSetting = TimerSettingsViewState.Data.Setting(
                 title = R.string.label_routine_settings_sound,
                 enabled = true
@@ -54,8 +57,37 @@ internal class TimerSettingsViewModelTest {
     }
 
     @Test
+    fun `should update keep screen on setting when keep screen on is toggled`() = coroutineRule {
+        val expected = TimerSettingsViewState.Data(
+            keepScreenOnSetting = TimerSettingsViewState.Data.Setting(
+                title = R.string.label_routine_settings_keep_screen_on,
+                enabled = false
+            ),
+            soundSetting = TimerSettingsViewState.Data.Setting(
+                title = R.string.label_routine_settings_sound,
+                enabled = true
+            ),
+            runInBackgroundSetting = TimerSettingsViewState.Data.Setting(
+                title = R.string.label_routine_settings_background,
+                enabled = false
+            )
+        )
+        val viewModel = buildViewModel()
+
+        viewModel.onToggleKeepScreenOn()
+
+        viewModel.viewState.test {
+            assertThat(awaitItem()).isEqualTo(expected)
+        }
+    }
+
+    @Test
     fun `should update sound setting when sound is toggled`() = coroutineRule {
         val expected = TimerSettingsViewState.Data(
+            keepScreenOnSetting = TimerSettingsViewState.Data.Setting(
+                title = R.string.label_routine_settings_keep_screen_on,
+                enabled = true
+            ),
             soundSetting = TimerSettingsViewState.Data.Setting(
                 title = R.string.label_routine_settings_sound,
                 enabled = false
@@ -77,6 +109,10 @@ internal class TimerSettingsViewModelTest {
     @Test
     fun `should update run in background setting when run in background is toggled`() = coroutineRule {
         val expected = TimerSettingsViewState.Data(
+            keepScreenOnSetting = TimerSettingsViewState.Data.Setting(
+                title = R.string.label_routine_settings_keep_screen_on,
+                enabled = true
+            ),
             soundSetting = TimerSettingsViewState.Data.Setting(
                 title = R.string.label_routine_settings_sound,
                 enabled = true


### PR DESCRIPTION
Add a new setting that allows the user to enable or disable the ability to keep the phone screen on when the timer is running