### PR TITLE
Fix: Attempt to invoke interface WindowScreenManager on a null object reference

### DIFF
--- a/base/viewmodel/src/main/java/com/enricog/base/viewmodel/BaseViewModel.kt
+++ b/base/viewmodel/src/main/java/com/enricog/base/viewmodel/BaseViewModel.kt
@@ -43,7 +43,6 @@ open class BaseViewModel<ViewModelState : Any, ViewState : Any>(
     init {
         viewModelStateFlow
             .debounce(configuration.debounce)
-            .onEach(::onStateUpdated)
             .map(converter::convert)
             .flowOn(dispatchers.cpu)
             .distinctUntilChanged()
@@ -52,7 +51,11 @@ open class BaseViewModel<ViewModelState : Any, ViewState : Any>(
             .launchIn(viewModelScope)
     }
 
-    protected open fun onStateUpdated(currentState: ViewModelState) {}
+    protected fun onStateUpdate(block: (ViewModelState) -> Unit) {
+        viewModelStateFlow
+            .onEach(block)
+            .launchIn(viewModelScope)
+    }
 
     protected open fun updateStateError(throwable: Throwable) {
         TempoLogger.e(throwable = throwable, message = "Error viewState value")

--- a/features/timer/src/main/java/com/enricog/features/timer/TimerViewModel.kt
+++ b/features/timer/src/main/java/com/enricog/features/timer/TimerViewModel.kt
@@ -57,6 +57,7 @@ internal class TimerViewModel @Inject constructor(
         getTimerSettingsUseCase()
             .onEach { timerSettings -> timerController.onTimerSettingsChanged(timerSettings = timerSettings) }
             .launchIn(viewModelScope)
+        onStateUpdate(::onStateUpdated)
 
         load(input)
     }
@@ -120,7 +121,7 @@ internal class TimerViewModel @Inject constructor(
         }
     }
 
-    override fun onStateUpdated(currentState: TimerState) {
+    private fun onStateUpdated(currentState: TimerState) {
         toggleKeepScreenOn(currentState = currentState)
         toggleBackgroundService(currentState = currentState)
     }


### PR DESCRIPTION
This bug bothered me for a long time: way too many nights thinking about what was causing this problem.
Stupid solutions attempts have been made, some have PRs (for example https://github.com/guerraenrico/tempo/pull/93) others will never see the light and are lost forever probably for good.

This is a tale of a not-null property being null. 

`WindowScreenManager` is used in `TimerViewModel` to set the property to keep the screen on.
This instance should never be null but randomly an exception was thrown because the instance was null.

After months of thinking about this during the night (to be fair I didn't spend much time debugging it I was just thinking about it without looking even at the code), I was finally able to find the problem (which funny enough I think I had a similar case in the past but I forgot about it).

The problem is here: (code simplified)
```
open class BaseViewModel(...) {
  init {
     viewModelStateFlow
            .debounce(configuration.debounce)
            .onEach(::onStateUpdated)  // <---
  }

  protected open fun onStateUpdated(currentState: ViewModelState) {}
}
```
```
class TimerViewModel(
  private val windowScreenManager: WindowScreenManager,
  ...
): BaseViewModel(...) {

  private fun onStateUpdated(currentState: TimerState) {
    ... 
    windowScreenManager.toggleKeepScreenOnFlag(enableKeepScreenOn) // <--- Exceptions was thrown here
  }
}
```

Do you see the problem here? I wasn't able to find the problem until I decided to look at the generated java class which is something like this: (I just reported the part of interest)

```
...
@Inject
public TimerViewModel(@NotNull WindowScreenManager windowScreenManager, ...) {
  Intrinsics.checkNotNullParameter(windowScreenManager, "windowScreenManager");
  ...
  super(Idle.INSTANCE, (StateConverter)converter, dispatchers, new ViewModelConfiguration(0L));
  ...
  this.windowScreenManager = windowScreenManager;
}
```

Well now you can see what the problem is: the property `WindowScreenManager` (but also all the others) is initialized only after the base class constructor is called. Since in the base class init method, a flow was launched that was calling a function in the `TimerViewModel` that was using a property that could have not been initialized yet.
I say could because here we have a race condition between the flow emission of an item and the initialization of the property.

Once understood this the fix is pretty trivial.

What a shame.

