### PR TITLE
Fix: Play sounds in background

### DIFF
--- a/features/timer/src/main/java/com/enricog/features/timer/TimerSoundPlayer.kt
+++ b/features/timer/src/main/java/com/enricog/features/timer/TimerSoundPlayer.kt
@@ -33,7 +33,10 @@ internal class TimerSoundPlayer @Inject constructor(
             state.isStepCountAt(1800.seconds) -> MIN_30_SPEECH
             state.isStepCountAt(2700.seconds) -> MIN_45_SPEECH
 
-            else -> return
+            else -> {
+                soundPlayer.keepAlive(COUNT_DOWN_SOUND)
+                return
+            }
         }
 
         soundPlayer.play(soundResId = soundToPlay)

--- a/features/timer/src/main/java/com/enricog/features/timer/TimerSoundPlayer.kt
+++ b/features/timer/src/main/java/com/enricog/features/timer/TimerSoundPlayer.kt
@@ -40,7 +40,7 @@ internal class TimerSoundPlayer @Inject constructor(
     }
 
     private val TimerState.Counting.isStepCountCompleting: Boolean
-        get() = isStepCountRunning && !isStopwatchRunning &&
+        get() = isStepCountRunning && !isStepCountCompleted && !isStopwatchRunning &&
             runningStep.count.seconds <= STEP_COMPLETING_THRESHOLD
 
     private val TimerState.Counting.isRestStarted: Boolean

--- a/features/timer/src/main/java/com/enricog/features/timer/models/TimerState.kt
+++ b/features/timer/src/main/java/com/enricog/features/timer/models/TimerState.kt
@@ -40,7 +40,7 @@ internal sealed class TimerState {
             get() = steps.getOrNull(index = runningStepIndex - 1)
 
         val isStepCountRunning: Boolean
-            get() = runningStep.count.isRunning && !runningStep.count.isCompleted
+            get() = runningStep.count.isRunning
 
         val isStepCountCompleted: Boolean
             get() = runningStep.count.isCompleted

--- a/features/timer/src/main/java/com/enricog/features/timer/service/TimerService.kt
+++ b/features/timer/src/main/java/com/enricog/features/timer/service/TimerService.kt
@@ -121,10 +121,10 @@ internal class TimerService : Service() {
     }
 
     private fun createNotification(stateHistory: StateHistory): Notification {
-
         createChannel()
 
         return NotificationCompat.Builder(applicationContext, channelId)
+            .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
             .setSmallIcon(R.drawable.ic_notification)
             .setSilent(true)
             .setColorized(true)

--- a/features/timer/src/test/java/com/enricog/features/timer/models/TimerStateTest.kt
+++ b/features/timer/src/test/java/com/enricog/features/timer/models/TimerStateTest.kt
@@ -69,40 +69,6 @@ internal class TimerStateTest {
     )
 
     @Test
-    fun `test when step count is running`() {
-        val arguments = listOf(
-            count.copy(isRunning = true, isCompleted = false) to true,
-            count.copy(isRunning = true, isCompleted = true) to false,
-            count.copy(isRunning = false, isCompleted = true) to false,
-            count.copy(isRunning = false, isCompleted = false) to false
-        )
-        val inputs = arguments.map { (count, expected) ->
-            state.copy(runningStep = state.runningStep.copy(count = count)) to expected
-        }
-
-        inputs.forEach { (state, expected) ->
-            val actual = state.isStepCountRunning
-            assertThat(actual).isEqualTo(expected)
-        }
-    }
-
-    @Test
-    fun `test when step count is completed`() {
-        val arguments = listOf(
-            count.copy(isRunning = true, isCompleted = false) to false,
-            count.copy(isRunning = true, isCompleted = true) to true
-        )
-        val inputs = arguments.map { (count, expected) ->
-            state.copy(runningStep = state.runningStep.copy(count = count)) to expected
-        }
-
-        inputs.forEach { (state, expected) ->
-            val actual = state.isStepCountCompleted
-            assertThat(actual).isEqualTo(expected)
-        }
-    }
-
-    @Test
     fun `test when routine is completed`() {
         val inputs = listOf(
             state.copy(
@@ -179,7 +145,7 @@ internal class TimerStateTest {
                     type = SegmentStepType.IN_PROGRESS,
                     segment = Segment.EMPTY.copy(id = 2.asID, type = TimeType.STOPWATCH)
                 )
-            ) to false,
+            ) to true,
             state.copy(
                 runningStep = SegmentStep(
                     id = 3,

--- a/libraries/sound/api/src/main/java/com/enricog/libraries/sound/api/SoundPlayer.kt
+++ b/libraries/sound/api/src/main/java/com/enricog/libraries/sound/api/SoundPlayer.kt
@@ -7,5 +7,5 @@ interface SoundPlayer : Closeable {
 
     fun play(@RawRes soundResId: Int)
 
-    fun release(@RawRes soundResId: Int)
+    fun keepAlive(@RawRes soundResId: Int)
 }

--- a/libraries/sound/api/src/main/java/com/enricog/libraries/sound/api/SoundPlayerImpl.kt
+++ b/libraries/sound/api/src/main/java/com/enricog/libraries/sound/api/SoundPlayerImpl.kt
@@ -1,45 +1,71 @@
 package com.enricog.libraries.sound.api
 
 import android.content.Context
+import android.media.AudioAttributes
+import android.media.AudioManager
 import android.media.MediaPlayer
 import android.media.MediaPlayer.OnErrorListener
 import androidx.annotation.RawRes
 import com.enricog.core.logger.api.TempoLogger
 import dagger.hilt.android.qualifiers.ApplicationContext
-import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 
 internal class SoundPlayerImpl @Inject constructor(
     @ApplicationContext private val context: Context
 ) : SoundPlayer, OnErrorListener {
 
-    private val players = ConcurrentHashMap<Int, MediaPlayer>()
+    private val audioManager = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
+    private val audioSessionId = audioManager.generateAudioSessionId()
+    private var lastSoundResId = -1
+    private var player: MediaPlayer? = null
 
     override fun play(soundResId: Int) {
-        val player = createPlayerIfNeeded(soundResId = soundResId)
-        player.start()
+        createPlayerIfNeeded(soundResId = soundResId).apply {
+            setVolume(1f, 1f)
+            start()
+        }
     }
 
-    private fun createPlayerIfNeeded(@RawRes soundResId: Int): MediaPlayer {
-        return players.getOrPut(soundResId) {
-            MediaPlayer.create(context, soundResId).apply {
-                isLooping = false
-                setOnErrorListener(this@SoundPlayerImpl)
+    override fun keepAlive(soundResId: Int) {
+        if (player?.isPlaying == false) {
+            createPlayerIfNeeded(soundResId).apply {
+                setVolume(0f, 0f)
+                start()
             }
         }
     }
 
-    override fun release(soundResId: Int) {
-        releasePlayer(soundResId = soundResId)
+    private fun createPlayerIfNeeded(@RawRes soundResId: Int): MediaPlayer {
+        return player
+            ?.takeIf { lastSoundResId == soundResId }
+            ?: createPlayer(soundResId)
+    }
+
+    private fun createPlayer(@RawRes soundResId: Int): MediaPlayer {
+        val newPlayer = player?.apply { reset() } ?: MediaPlayer()
+        return newPlayer
+            .apply {
+                audioSessionId = this@SoundPlayerImpl.audioSessionId
+                setAudioAttributes(AudioAttributes.Builder().build())
+
+                val adf = context.resources.openRawResourceFd(soundResId)
+                setDataSource(adf)
+                adf.close()
+
+                isLooping = false
+                setOnErrorListener(this@SoundPlayerImpl)
+                prepare()
+            }
+            .also {
+                lastSoundResId = soundResId
+                player = it
+            }
     }
 
     override fun close() {
-        players.keys.forEach(::releasePlayer)
-    }
-
-    private fun releasePlayer(@RawRes soundResId: Int) {
-        players[soundResId]?.release()
-        players.remove(soundResId)
+        player?.release()
+        player = null
+        lastSoundResId = -1
     }
 
     override fun onError(mp: MediaPlayer?, what: Int, extra: Int): Boolean {

--- a/libraries/sound/testing/src/main/java/com/enricog/libraries/sound/testing/FakeSoundPlayer.kt
+++ b/libraries/sound/testing/src/main/java/com/enricog/libraries/sound/testing/FakeSoundPlayer.kt
@@ -12,8 +12,8 @@ class FakeSoundPlayer : SoundPlayer {
         playedSounds[soundResId] = count + 1
     }
 
-    override fun release(soundResId: Int) {
-        playedSounds.remove(soundResId)
+    override fun keepAlive(soundResId: Int) {
+        // no-op
     }
 
     override fun close() {


### PR DESCRIPTION
Fix sound play when the app is in background.

There are 2 problems in order to fix this:
- the `TimerTask` that changes the running step is not starting 
- the `MediaPlayer` is not playing the resource after some seconds and it plays randomly.

Both of this problems share the same issue: when the phone is idle (the user press the power button), android tries to save resources that are not used in this case the CPU and sound.

In order to fix this, which might look more of a workaround, it's to keep those resource active.
For the `TimerTask the solution made actually the timer work better: instead of stopping the `CountingTimerTask` when swithcing to the next step by starting another `TimerTask`, the same `CountingTimerTask` is used to do move to the next step without stopping it. 
This simplified also the code and made it more predictable.

For the `MediaPlayer` the solution is more hacky: in order to keep the resource active at each second a resource is being played to keep it alive and avoid the OS to release the resources. 
It has been reviewed how the `SoundPlayer` implementation work, instead of having multiple `MediaPlayer` one for each resource, the same instance is used and when it is required to play a different resource it is resetted.