### PR TITLE
Fix: Include number of rounds when calculating routine estimated time

### DIFF
--- a/data/routines/api/src/main/java/com/enricog/data/routines/api/entities/Routine.kt
+++ b/data/routines/api/src/main/java/com/enricog/data/routines/api/entities/Routine.kt
@@ -35,14 +35,13 @@ data class Routine(
 
     val expectedTotalTime: Seconds
         get() {
-            val segmentsTotalTime = segments.map { it.time }
+            val segmentsTotalTime = segments.map { it.time * it.rounds }
                 .reduce { acc, time -> acc + time }
+                .takeIf { it > 0.seconds } ?: return 0.seconds
             val preparationTotalTime = preparationTime * segments.count {
                 it.type.requirePreparationTime
             }
-            if (segmentsTotalTime == 0.seconds)
-                return 0.seconds
-            return segmentsTotalTime + preparationTotalTime
+            return (segmentsTotalTime + preparationTotalTime) * rounds
         }
 
     fun getNewSegmentRank(): Rank {

--- a/data/routines/api/src/test/java/com/enricog/data/routines/api/entities/RoutineTest.kt
+++ b/data/routines/api/src/test/java/com/enricog/data/routines/api/entities/RoutineTest.kt
@@ -95,7 +95,7 @@ class RoutineTest {
 
     @Test
     fun `on init should throw exception when number of rounds is less than one`() {
-        val rounds = 1
+        val rounds = 0
 
         assertThrows(IllegalArgumentException::class.java) {
             Routine(
@@ -224,7 +224,7 @@ class RoutineTest {
                     name = "",
                     time = 30.seconds,
                     type = TimeType.TIMER,
-                    rank = Rank.from("aaaaaa"),
+                    rank = Rank.from("cccccc"),
                     rounds = 1
                 ),
                 Segment(
@@ -232,7 +232,7 @@ class RoutineTest {
                     name = "",
                     time = 0.seconds,
                     type = TimeType.STOPWATCH,
-                    rank = Rank.from("aaaaaa"),
+                    rank = Rank.from("dddddd"),
                     rounds = 1
                 )
             ),
@@ -241,6 +241,59 @@ class RoutineTest {
             frequencyGoal = null
         )
         val expected = 180.seconds
+
+        val actual = routine.expectedTotalTime
+
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun `expected total time should count the numbers of rounds`() {
+        val routine = Routine(
+            id = 0.asID,
+            name = "",
+            preparationTime = 30.seconds,
+            createdAt = OffsetDateTime.MAX,
+            updatedAt = OffsetDateTime.MAX,
+            segments = listOf(
+                Segment(
+                    id = ID.new(),
+                    name = "",
+                    time = 30.seconds,
+                    type = TimeType.TIMER,
+                    rank = Rank.from("aaaaaa"),
+                    rounds = 2
+                ),
+                Segment(
+                    id = ID.new(),
+                    name = "",
+                    time = 30.seconds,
+                    type = TimeType.REST,
+                    rank = Rank.from("bbbbbb"),
+                    rounds = 1
+                ),
+                Segment(
+                    id = ID.new(),
+                    name = "",
+                    time = 30.seconds,
+                    type = TimeType.TIMER,
+                    rank = Rank.from("cccccc"),
+                    rounds = 3
+                ),
+                Segment(
+                    id = ID.new(),
+                    name = "",
+                    time = 0.seconds,
+                    type = TimeType.STOPWATCH,
+                    rank = Rank.from("dddddd"),
+                    rounds = 1
+                )
+            ),
+            rank = Rank.from("aaaaaa"),
+            rounds = 2,
+            frequencyGoal = null
+        )
+        val expected = 540.seconds
 
         val actual = routine.expectedTotalTime
 


### PR DESCRIPTION
Fix routine estimated time calculation including the number or rounds of the routine and segments